### PR TITLE
Secure local Grafana authentication

### DIFF
--- a/.github/workflows/local-stack.yml
+++ b/.github/workflows/local-stack.yml
@@ -24,11 +24,12 @@ jobs:
           mkdir -p secrets
           printf 'local-ci-placeholder\n' > secrets/grafana-cloud-instance-id
           printf 'local-ci-placeholder\n' > secrets/grafana-cloud-api-token
+          printf 'admin\n' > secrets/grafana-admin-password
 
       - name: Prepare local storage directories
         run: |
-          mkdir -p prometheus/storage loki/storage tempo/storage pyroscope/storage
-          chmod -R 777 prometheus/storage loki/storage tempo/storage pyroscope/storage
+          mkdir -p grafana/storage prometheus/storage loki/storage tempo/storage pyroscope/storage
+          chmod -R 777 grafana/storage prometheus/storage loki/storage tempo/storage pyroscope/storage
 
       - name: Validate verification script
         run: bash -n scripts/verify-local-stack.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ secrets:
     file: ./secrets/grafana-cloud-instance-id
   grafana_cloud_api_token:
     file: ./secrets/grafana-cloud-api-token
+  grafana_admin_password:
+    file: ./secrets/grafana-admin-password
 
 services:
   prometheus:
@@ -32,9 +34,10 @@ services:
     ports: 
       - 82:3000
     environment: 
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD__FILE=/run/secrets/grafana_admin_password
       - GF_PLUGINS_PREINSTALL=grafana-assistant-app
       - GF_SERVER_ROOT_URL=http://localhost:82/
       - GF_TRACING_OPENTELEMETRY_OTLP_ADDRESS=otel-collector:4317
@@ -44,6 +47,9 @@ services:
       - GF_DIAGNOSTICS_PROFILING_PORT=6060
     volumes: 
       - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/storage:/var/lib/grafana
+    secrets:
+      - grafana_admin_password
     depends_on:
       - loki
       - otel-collector

--- a/scripts/verify-local-stack.sh
+++ b/scripts/verify-local-stack.sh
@@ -7,6 +7,8 @@ START_STACK=1
 TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-180}
 
 GRAFANA_URL=${GRAFANA_URL:-http://localhost:82}
+GRAFANA_USER=${GRAFANA_USER:-admin}
+GRAFANA_PASSWORD_FILE=${GRAFANA_PASSWORD_FILE:-secrets/grafana-admin-password}
 PROMETHEUS_URL=${PROMETHEUS_URL:-http://localhost:81}
 ALERTMANAGER_URL=${ALERTMANAGER_URL:-http://localhost:83}
 LOKI_URL=${LOKI_URL:-http://localhost:3100}
@@ -78,6 +80,19 @@ need_cmd() {
 run() {
   log "$*"
   "$@"
+}
+
+load_grafana_password() {
+  if [[ -n "${GRAFANA_PASSWORD:-}" ]]; then
+    return
+  fi
+
+  if [[ ! -f "$GRAFANA_PASSWORD_FILE" ]]; then
+    fail "Missing Grafana admin password file: ${GRAFANA_PASSWORD_FILE}"
+  fi
+
+  GRAFANA_PASSWORD=$(<"$GRAFANA_PASSWORD_FILE")
+  export GRAFANA_PASSWORD
 }
 
 wait_until() {
@@ -197,7 +212,7 @@ PY
 grafana_datasource_is_healthy() {
   local uid=$1
   local response
-  response=$(curl -fsS -u admin:admin "${GRAFANA_URL}/api/datasources/uid/${uid}/health")
+  response=$(curl -fsS -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" "${GRAFANA_URL}/api/datasources/uid/${uid}/health")
 
   RESPONSE="$response" python3 - <<'PY'
 import json
@@ -233,13 +248,21 @@ check_running_services() {
   fi
 }
 
+prepare_local_storage() {
+  mkdir -p grafana/storage
+  chmod 777 grafana/storage
+}
+
 need_cmd docker
 need_cmd curl
 need_cmd python3
 
+load_grafana_password
+
 run $COMPOSE config --quiet
 
 if (( START_STACK == 1 )); then
+  prepare_local_storage
   run $COMPOSE up -d
 fi
 


### PR DESCRIPTION
## Summary
- Require authenticated local Grafana access instead of anonymous Admin access.
- Store the Grafana admin password through a Docker secret and persist Grafana state locally.
- Update local-stack verification and CI placeholders to use the same authenticated setup.

## Test plan
- `bash -n scripts/verify-local-stack.sh`
- `docker compose config --quiet`
- `./scripts/verify-local-stack.sh --timeout 900`
- Confirm unauthenticated `/api/user` returns `401` and authenticated access returns `200`.


Made with [Cursor](https://cursor.com)