### PR TITLE
Set local Prometheus scrape interval

### DIFF
--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -7,5 +7,7 @@ datasources:
   access: proxy
   orgId: 1
   url: http://prometheus:9090
-  version: 1
+  jsonData:
+    timeInterval: 60s
+  version: 2
   editable: true


### PR DESCRIPTION
## Summary
- Configure the local Prometheus datasource with a 60s scrape interval so Grafana expands `$__rate_interval` correctly.
- Bump the provisioned datasource version so existing local Grafana instances apply the jsonData update.

## Test plan
- Verified the OpenTelemetry Collector dashboard renders data locally after restarting Grafana.
- Queried the local Grafana datasource API and confirmed the `$__rate_interval` panel query returns values.


Made with [Cursor](https://cursor.com)