### PR TITLE
Add Garmin exporter to local stack

### DIFF
--- a/.github/workflows/local-stack.yml
+++ b/.github/workflows/local-stack.yml
@@ -25,6 +25,10 @@ jobs:
           printf 'local-ci-placeholder\n' > secrets/grafana-cloud-instance-id
           printf 'local-ci-placeholder\n' > secrets/grafana-cloud-api-token
           printf 'admin\n' > secrets/grafana-admin-password
+          printf '%s\n' \
+            'GARMIN_USERNAME=local-ci-placeholder' \
+            'GARMIN_PASSWORD=local-ci-placeholder' \
+            > secrets/garmin.env
 
       - name: Prepare local storage directories
         run: |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,21 @@ It is intentionally small enough to run with Docker Compose, but complete enough
 | [Alertmanager](https://github.com/prometheus/alertmanager) | Alert routing and tracing target. |
 | [Node Exporter](https://github.com/prometheus/node_exporter) | Host metrics. |
 | [Blackbox Exporter](https://github.com/prometheus/blackbox_exporter) | External endpoint probing. |
+| [Garmin Exporter](https://github.com/barnes-c/garmin_exporter) | Garmin Connect health and training metrics (scraped every 5m). |
 | Grafana Cloud | Remote metrics, logs, traces, and profiles for cloud dogfooding. |
+
+### Garmin credentials
+
+Create `secrets/garmin.env` (gitignored) before starting the stack:
+
+```bash
+printf '%s\n' \
+  'GARMIN_USERNAME=you@example.com' \
+  'GARMIN_PASSWORD=your-password' \
+  > secrets/garmin.env
+```
+
+CI uses placeholder credentials; the exporter may fail login and restart, but the collector still scrapes the target and Prometheus records `up{job="garmin_exporter"}` (often `0`).
 
 ## Grafana Cloud Git Sync
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,15 @@ services:
     ports: 
       - "9100:9100"
 
+  garmin_exporter:
+    image: ghcr.io/barnes-c/garmin_exporter@sha256:61f10b7165c2b0f95a9f3a7892fdd28e4be176666a6645ec8c905fe125577911
+    restart: unless-stopped
+    env_file:
+      - ./secrets/garmin.env
+    command:
+      - --garmin.token-file=/data/garmin_token.json
+    volumes:
+      - garmin_data:/data
 
   blackbox_exporter: 
     image: prom/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
@@ -123,6 +132,10 @@ services:
       - grafana_cloud_instance_id
       - grafana_cloud_api_token
     depends_on:
+      - garmin_exporter
       - loki
       - tempo
       - pyroscope
+
+volumes:
+  garmin_data:

--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -24,6 +24,11 @@ receivers:
         - job_name: 'node_exporter'
           static_configs:
             - targets: ['node_exporter:9100']
+        - job_name: 'garmin_exporter'
+          scrape_interval: 5m
+          scrape_timeout: 2m
+          static_configs:
+            - targets: ['garmin_exporter:10043']
         - job_name: 'blackbox'
           metrics_path: /probe
           params:

--- a/scripts/verify-local-stack.sh
+++ b/scripts/verify-local-stack.sh
@@ -18,6 +18,7 @@ PYROSCOPE_URL=${PYROSCOPE_URL:-http://localhost:4040}
 EXPECTED_PROMETHEUS_JOBS=(
   alertmanager
   blackbox
+  garmin_exporter
   grafana
   loki
   node_exporter
@@ -25,6 +26,11 @@ EXPECTED_PROMETHEUS_JOBS=(
   prometheus
   pyroscope
   tempo
+)
+
+# Services that may exit or restart when credentials are invalid (e.g. CI placeholders).
+COMPOSE_RUNNING_OPTIONAL_SERVICES=(
+  garmin_exporter
 )
 
 usage() {
@@ -127,6 +133,7 @@ prometheus_query() {
 
 prometheus_has_expected_jobs() {
   local response
+  # Includes targets with up=0 (e.g. garmin_exporter when login fails in CI).
   response=$(prometheus_query 'count by (job) (up)')
 
   RESPONSE="$response" EXPECTED_JOBS="${EXPECTED_PROMETHEUS_JOBS[*]}" python3 - <<'PY'
@@ -237,8 +244,10 @@ generate_activity() {
 }
 
 check_running_services() {
-  local expected running missing
+  local expected running missing optional
   expected=$($COMPOSE config --services | sort)
+  optional=$(printf '%s\n' "${COMPOSE_RUNNING_OPTIONAL_SERVICES[@]}" | sort)
+  expected=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$optional"))
   running=$($COMPOSE ps --status running --services | sort)
   missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$running"))
 


### PR DESCRIPTION
## Summary

- Add `garmin_exporter` to Docker Compose with a persistent token volume and credentials from `secrets/garmin.env`.
- Scrape the exporter every 5 minutes via the OpenTelemetry Collector prometheus receiver.
- Extend local stack CI verification to require the `garmin_exporter` Prometheus job (including when `up == 0` with placeholder credentials).

## Test plan

- [ ] CI `Verify local stack` passes
- [ ] Locally: create `secrets/garmin.env`, run `docker compose up -d garmin_exporter`, confirm login and `up{job="garmin_exporter"} == 1` after scrape


Made with [Cursor](https://cursor.com)