### PR TITLE
Pin Garmin exporter release tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - "9100:9100"
 
   garmin_exporter:
-    image: ghcr.io/barnes-c/garmin_exporter@sha256:61f10b7165c2b0f95a9f3a7892fdd28e4be176666a6645ec8c905fe125577911
+    image: ghcr.io/barnes-c/garmin_exporter:0.1.2@sha256:61f10b7165c2b0f95a9f3a7892fdd28e4be176666a6645ec8c905fe125577911
     restart: unless-stopped
     env_file:
       - ./secrets/garmin.env


### PR DESCRIPTION
## Summary
- Pin the Garmin exporter image to the explicit `0.1.2` release tag while keeping the existing immutable digest.

## Test plan
- Recreated `garmin_exporter` with `docker compose up -d --no-deps garmin_exporter`.
- Verified the service is running and logs report `version=v0.1.2`.


Made with [Cursor](https://cursor.com)