### PR TITLE
Enable collector self tracing

### DIFF
--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -313,6 +313,9 @@ extensions:
 service:
   extensions: [docker_observer, basicauth/grafana_cloud, pprof, zpages, health_check]
   telemetry:
+    resource:
+      service.name: otel-collector
+      service.namespace: home-monitoring
     metrics:
       readers:
         - pull:
@@ -320,6 +323,13 @@ service:
               prometheus:
                 host: 0.0.0.0
                 port: 8888
+    traces:
+      processors:
+        - batch:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: http://127.0.0.1:4318
   pipelines:
     metrics:
       receivers: [otlp, prometheus]

--- a/scripts/verify-local-stack.sh
+++ b/scripts/verify-local-stack.sh
@@ -22,7 +22,7 @@ EXPECTED_PROMETHEUS_JOBS=(
   grafana
   loki
   node_exporter
-  otelcol-contrib
+  home-monitoring/otel-collector
   prometheus
   pyroscope
   tempo


### PR DESCRIPTION
## Summary
- Configure the OpenTelemetry Collector internal telemetry resource attributes so it reports as `otel-collector` in the `home-monitoring` namespace.
- Export collector internal traces to the local OTLP HTTP receiver so the existing trace pipeline forwards them to Tempo and Grafana Cloud.

## Test plan
- `docker compose run --rm --no-deps otel-collector validate --config=/etc/otel-collector-config.yaml --feature-gates=service.profilesSupport`


Made with [Cursor](https://cursor.com)