### PR TITLE
Reduce local port exposure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,8 +71,6 @@ services:
   node_exporter:
     privileged: true
     image: prom/node-exporter:v1.11.1@sha256:e9cff4fc67b1818f8c97adb115b9f12c9a54b533de86765d4a0effc01b357205
-    ports: 
-      - "9100:9100"
 
   garmin_exporter:
     image: ghcr.io/barnes-c/garmin_exporter:0.1.2@sha256:61f10b7165c2b0f95a9f3a7892fdd28e4be176666a6645ec8c905fe125577911
@@ -94,8 +92,6 @@ services:
     volumes:
       - ./loki/config.yaml:/etc/loki/config.yaml
       - ./loki/storage:/loki
-    ports:
-      - "3100:3100"
 
   tempo:
     image: grafana/tempo:2.10.5@sha256:ee21727732c7a7199cb71c3eee9153bbf23f9b0b87619f0555a0cf21a67f1a33
@@ -104,8 +100,6 @@ services:
     volumes:
       - ./tempo/config.yaml:/etc/tempo/config.yaml
       - ./tempo/storage:/var/tempo
-    ports:
-      - "3200:3200"
 
   pyroscope:
     image: grafana/pyroscope:2.0.2@sha256:644515bfa06cb3779b8666514b1bab2295bd11f1e1a53834bd9584a43f77c4f5
@@ -116,8 +110,6 @@ services:
       - server
     volumes:
       - ./pyroscope/storage:/var/lib/pyroscope
-    ports:
-      - "4040:4040"
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.152.1@sha256:fa1f6ea8dabd3042fabf4411eed7fa52f253edd8940140bec89a573e62a24eb7


### PR DESCRIPTION
## Summary
- Remove host-published ports for services that are only accessed over the Docker network.
- Keep Grafana, Prometheus, and Alertmanager host ports unchanged for local UI/API access.

## Test plan
- `docker compose config --quiet`


Made with [Cursor](https://cursor.com)