### PR TITLE
Configure App O11y resource attributes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       - --web.enable-lifecycle
       - --storage.tsdb.retention.time=2d
       - --web.enable-remote-write-receiver
-      - --enable-feature=otlp-write-receiver,created-timestamp-zero-ingestion,native-histograms,promql-experimental-functions
+      - --web.enable-otlp-receiver
+      - --enable-feature=created-timestamp-zero-ingestion,promql-experimental-functions
     depends_on:
       - otel-collector
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - --storage.tsdb.retention.time=2d
       - --web.enable-remote-write-receiver
       - --web.enable-otlp-receiver
-      - --enable-feature=created-timestamp-zero-ingestion,otlp-deltatocumulative,promql-experimental-functions
+      - --enable-feature=created-timestamp-zero-ingestion,promql-experimental-functions
     depends_on:
       - otel-collector
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - --storage.tsdb.retention.time=2d
       - --web.enable-remote-write-receiver
       - --web.enable-otlp-receiver
-      - --enable-feature=created-timestamp-zero-ingestion,promql-experimental-functions
+      - --enable-feature=created-timestamp-zero-ingestion,otlp-deltatocumulative,promql-experimental-functions
     depends_on:
       - otel-collector
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,11 @@ secrets:
 
 services:
   prometheus:
-    image: prom/prometheus:v3.0.0-beta.0@sha256:064b379ac7f9d34c5b9b6cdd8c68a5706603270c0594bdefed67cd85c3b290be
+    image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
     restart: always # To re-read the configuration file
     user: "1000:1000"
+    environment:
+      - OTEL_SERVICE_NAME=prometheus
     ports:
       - 81:9090
     volumes: 
@@ -40,6 +42,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD__FILE=/run/secrets/grafana_admin_password
       - GF_PLUGINS_PREINSTALL=grafana-assistant-app
       - GF_SERVER_ROOT_URL=http://localhost:82/
+      - OTEL_SERVICE_NAME=grafana
       - GF_TRACING_OPENTELEMETRY_OTLP_ADDRESS=otel-collector:4317
       - GF_TRACING_OPENTELEMETRY_OTLP_PROPAGATION=w3c
       - GF_DIAGNOSTICS_PROFILING_ENABLED=true
@@ -58,6 +61,8 @@ services:
 
   alertmanager:
     image: prom/alertmanager:v0.32.1@sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286
+    environment:
+      - OTEL_SERVICE_NAME=alertmanager
     ports: 
       - 83:9093
     command:

--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -215,6 +215,14 @@ exporters:
 
 processors:
   batch:
+  resource/home_monitoring:
+    attributes:
+      - key: service.namespace
+        value: home-monitoring
+        action: insert
+      - key: deployment.environment
+        value: homelab
+        action: insert
   resource/profiles_prometheus:
     attributes:
       - key: service.name
@@ -333,15 +341,15 @@ service:
   pipelines:
     metrics:
       receivers: [otlp, prometheus]
-      processors: [batch]
+      processors: [resource/home_monitoring, batch]
       exporters: [otlp_http/grafana_cloud, otlp_http/prometheus]
     logs:
       receivers: [otlp, receiver_creator]
-      processors: [batch]
+      processors: [resource/home_monitoring, batch]
       exporters: [otlp_http/loki, otlp_http/grafana_cloud]
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [resource/home_monitoring, batch]
       exporters: [otlp_http/grafana_cloud, otlp_http/tempo]
     # Grafana Cloud's OTLP gateway does not support OTLP profiles yet.
     # Keep profiles local in Pyroscope until Cloud Profiles supports OTLP ingest.

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,6 +1,17 @@
 global:
   scrape_interval: 60s 
 
+otlp:
+  promote_resource_attributes:
+  - service.instance.id
+  - service.name
+  - service.namespace
+  - service.version
+  - deployment.environment
+  - deployment.environment.name
+  - container.name
+  keep_identifying_resource_attributes: true
+
 tracing:
   client_type: grpc
   endpoint: otel-collector:4317

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,10 +1,6 @@
 global:
   scrape_interval: 60s 
 
-storage:
-  tsdb:
-    out_of_order_time_window: 30m
-
 otlp:
   promote_resource_attributes:
   - service.instance.id

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,6 +1,10 @@
 global:
   scrape_interval: 60s 
 
+storage:
+  tsdb:
+    out_of_order_time_window: 30m
+
 otlp:
   promote_resource_attributes:
   - service.instance.id

--- a/scripts/verify-local-stack.sh
+++ b/scripts/verify-local-stack.sh
@@ -17,16 +17,16 @@ TEMPO_URL=${TEMPO_URL:-http://localhost:3200}
 PYROSCOPE_URL=${PYROSCOPE_URL:-http://localhost:4040}
 
 EXPECTED_PROMETHEUS_JOBS=(
-  alertmanager
-  blackbox
-  garmin_exporter
-  grafana
-  loki
-  node_exporter
+  home-monitoring/alertmanager
+  home-monitoring/blackbox
+  home-monitoring/garmin_exporter
+  home-monitoring/grafana
+  home-monitoring/loki
+  home-monitoring/node_exporter
   home-monitoring/otel-collector
-  prometheus
-  pyroscope
-  tempo
+  home-monitoring/prometheus
+  home-monitoring/pyroscope
+  home-monitoring/tempo
 )
 
 EXPECTED_PROFILE_RECEIVERS=(


### PR DESCRIPTION
## Summary
- Set explicit OTel service names for Prometheus, Grafana, and Alertmanager.
- Add collector-side App O11y resource enrichment for namespace and environment across metrics, logs, and traces.
- Upgrade Prometheus from beta to stable v3.11.3 and promote common OTel resource attributes locally.

## Test plan
- docker compose config --quiet
- docker compose run --rm --no-deps --entrypoint promtool prometheus check config /etc/prometheus/prometheus.yml
- docker compose run --rm --no-deps otel-collector validate --feature-gates=service.profilesSupport --config=/etc/otel-collector-config.yaml


Made with [Cursor](https://cursor.com)