### PR TITLE
Remove Garmin credentials README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,6 @@ It is intentionally small enough to run with Docker Compose, but complete enough
 | [Garmin Exporter](https://github.com/barnes-c/garmin_exporter) | Garmin Connect health and training metrics (scraped every 5m). |
 | Grafana Cloud | Remote metrics, logs, traces, and profiles for cloud dogfooding. |
 
-### Garmin credentials
-
-Create `secrets/garmin.env` (gitignored) before starting the stack:
-
-```bash
-printf '%s\n' \
-  'GARMIN_USERNAME=you@example.com' \
-  'GARMIN_PASSWORD=your-password' \
-  > secrets/garmin.env
-```
-
-CI uses placeholder credentials; the exporter may fail login and restart, but the collector still scrapes the target and Prometheus records `up{job="garmin_exporter"}` (often `0`).
-
 ## Grafana Cloud Git Sync
 
 Use [Grafana Git Sync](https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/) to keep dashboard JSON in this repository synced with Grafana Cloud.


### PR DESCRIPTION
## Summary
- Remove the Garmin credentials setup section from the README.

## Test plan
- Not run; documentation-only change.


Made with [Cursor](https://cursor.com)