### PR TITLE
Align App O11y service identity

### DIFF
--- a/grafana/provisioning/dashboards/home/opentelemetry-collector.json
+++ b/grafana/provisioning/dashboards/home/opentelemetry-collector.json
@@ -1316,7 +1316,7 @@
                         "app": "grafana-assistant-app",
                         "direction": "backward",
                         "editorMode": "code",
-                        "expr": "{service_name=\"home-monitoring-otel-collector-1\"}",
+                        "expr": "{service_name=\"otel-collector\"}",
                         "instant": false,
                         "queryType": "range",
                         "range": true

--- a/grafana/provisioning/dashboards/home/prometheus.json
+++ b/grafana/provisioning/dashboards/home/prometheus.json
@@ -1481,7 +1481,7 @@
                         },
                         "spec": {
                           "app": "grafana-assistant-app",
-                          "expr": "{service_name=\"home-monitoring-prometheus-1\"}",
+                          "expr": "{service_name=\"prometheus\"}",
                           "instant": false,
                           "queryType": "range",
                           "range": true

--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -29,7 +29,7 @@ receivers:
           scrape_timeout: 2m
           static_configs:
             - targets: ['garmin_exporter:10043']
-        - job_name: 'blackbox'
+        - job_name: 'blackbox_exporter'
           metrics_path: /probe
           params:
             module: [http_2xx]
@@ -196,6 +196,8 @@ receivers:
           container.image.name: '`image`'
           docker.compose.project: '`labels["com.docker.compose.project"]`'
           docker.compose.service: '`labels["com.docker.compose.service"]`'
+          service.name: '`labels["com.docker.compose.service"]`'
+          service.instance.id: '`name`'
 
 exporters:
   debug:
@@ -223,9 +225,15 @@ processors:
       - key: deployment.environment
         value: homelab
         action: insert
+      - key: deployment.environment.name
+        value: homelab
+        action: insert
   resource/profiles_prometheus:
     attributes:
       - key: service.name
+        value: prometheus
+        action: upsert
+      - key: service.instance.id
         value: prometheus
         action: upsert
       - key: service.namespace
@@ -236,12 +244,18 @@ processors:
       - key: service.name
         value: alertmanager
         action: upsert
+      - key: service.instance.id
+        value: alertmanager
+        action: upsert
       - key: service.namespace
         value: home-monitoring
         action: upsert
   resource/profiles_grafana:
     attributes:
       - key: service.name
+        value: grafana
+        action: upsert
+      - key: service.instance.id
         value: grafana
         action: upsert
       - key: service.namespace
@@ -252,12 +266,18 @@ processors:
       - key: service.name
         value: otel-collector
         action: upsert
+      - key: service.instance.id
+        value: otel-collector
+        action: upsert
       - key: service.namespace
         value: home-monitoring
         action: upsert
   resource/profiles_node_exporter:
     attributes:
       - key: service.name
+        value: node_exporter
+        action: upsert
+      - key: service.instance.id
         value: node_exporter
         action: upsert
       - key: service.namespace
@@ -268,12 +288,18 @@ processors:
       - key: service.name
         value: blackbox_exporter
         action: upsert
+      - key: service.instance.id
+        value: blackbox_exporter
+        action: upsert
       - key: service.namespace
         value: home-monitoring
         action: upsert
   resource/profiles_garmin_exporter:
     attributes:
       - key: service.name
+        value: garmin_exporter
+        action: upsert
+      - key: service.instance.id
         value: garmin_exporter
         action: upsert
       - key: service.namespace
@@ -284,6 +310,9 @@ processors:
       - key: service.name
         value: loki
         action: upsert
+      - key: service.instance.id
+        value: loki
+        action: upsert
       - key: service.namespace
         value: home-monitoring
         action: upsert
@@ -292,12 +321,18 @@ processors:
       - key: service.name
         value: tempo
         action: upsert
+      - key: service.instance.id
+        value: tempo
+        action: upsert
       - key: service.namespace
         value: home-monitoring
         action: upsert
   resource/profiles_pyroscope:
     attributes:
       - key: service.name
+        value: pyroscope
+        action: upsert
+      - key: service.instance.id
         value: pyroscope
         action: upsert
       - key: service.namespace
@@ -355,41 +390,41 @@ service:
     # Keep profiles local in Pyroscope until Cloud Profiles supports OTLP ingest.
     profiles/prometheus:
       receivers: [pprof/prometheus, pprof/prometheus_heap, pprof/prometheus_allocs, pprof/prometheus_goroutine]
-      processors: [resource/profiles_prometheus]
+      processors: [resource/home_monitoring, resource/profiles_prometheus]
       exporters: [otlp_http/pyroscope]
     profiles/alertmanager:
       receivers: [pprof/alertmanager, pprof/alertmanager_heap, pprof/alertmanager_allocs, pprof/alertmanager_goroutine]
-      processors: [resource/profiles_alertmanager]
+      processors: [resource/home_monitoring, resource/profiles_alertmanager]
       exporters: [otlp_http/pyroscope]
     profiles/grafana:
       receivers: [pprof/grafana, pprof/grafana_heap, pprof/grafana_allocs, pprof/grafana_goroutine]
-      processors: [resource/profiles_grafana]
+      processors: [resource/home_monitoring, resource/profiles_grafana]
       exporters: [otlp_http/pyroscope]
     profiles/otel-collector:
       receivers: [pprof/otel-collector, pprof/otel-collector_heap, pprof/otel-collector_allocs, pprof/otel-collector_goroutine]
-      processors: [resource/profiles_otel_collector]
+      processors: [resource/home_monitoring, resource/profiles_otel_collector]
       exporters: [otlp_http/pyroscope]
     profiles/node_exporter:
       receivers: [pprof/node_exporter, pprof/node_exporter_heap, pprof/node_exporter_allocs, pprof/node_exporter_goroutine]
-      processors: [resource/profiles_node_exporter]
+      processors: [resource/home_monitoring, resource/profiles_node_exporter]
       exporters: [otlp_http/pyroscope]
     profiles/blackbox_exporter:
       receivers: [pprof/blackbox_exporter, pprof/blackbox_exporter_heap, pprof/blackbox_exporter_allocs, pprof/blackbox_exporter_goroutine]
-      processors: [resource/profiles_blackbox_exporter]
+      processors: [resource/home_monitoring, resource/profiles_blackbox_exporter]
       exporters: [otlp_http/pyroscope]
     profiles/garmin_exporter:
       receivers: [pprof/garmin_exporter, pprof/garmin_exporter_heap, pprof/garmin_exporter_allocs, pprof/garmin_exporter_goroutine]
-      processors: [resource/profiles_garmin_exporter]
+      processors: [resource/home_monitoring, resource/profiles_garmin_exporter]
       exporters: [otlp_http/pyroscope]
     profiles/loki:
       receivers: [pprof/loki, pprof/loki_heap, pprof/loki_allocs, pprof/loki_goroutine]
-      processors: [resource/profiles_loki]
+      processors: [resource/home_monitoring, resource/profiles_loki]
       exporters: [otlp_http/pyroscope]
     profiles/tempo:
       receivers: [pprof/tempo, pprof/tempo_heap, pprof/tempo_allocs, pprof/tempo_goroutine]
-      processors: [resource/profiles_tempo]
+      processors: [resource/home_monitoring, resource/profiles_tempo]
       exporters: [otlp_http/pyroscope]
     profiles/pyroscope:
       receivers: [pprof/pyroscope, pprof/pyroscope_heap, pprof/pyroscope_allocs, pprof/pyroscope_goroutine]
-      processors: [resource/profiles_pyroscope]
+      processors: [resource/home_monitoring, resource/profiles_pyroscope]
       exporters: [otlp_http/pyroscope]

--- a/scripts/verify-local-stack.sh
+++ b/scripts/verify-local-stack.sh
@@ -18,7 +18,7 @@ PYROSCOPE_URL=${PYROSCOPE_URL:-http://localhost:4040}
 
 EXPECTED_PROMETHEUS_JOBS=(
   home-monitoring/alertmanager
-  home-monitoring/blackbox
+  home-monitoring/blackbox_exporter
   home-monitoring/garmin_exporter
   home-monitoring/grafana
   home-monitoring/loki
@@ -40,6 +40,18 @@ EXPECTED_PROFILE_RECEIVERS=(
   pprof/prometheus
   pprof/pyroscope
   pprof/tempo
+)
+
+EXPECTED_PROFILE_SERVICES=(
+  alertmanager
+  blackbox_exporter
+  grafana
+  loki
+  node_exporter
+  otel-collector
+  prometheus
+  pyroscope
+  tempo
 )
 
 # Services that may exit or restart when credentials are invalid (e.g. CI placeholders).
@@ -241,6 +253,35 @@ if missing:
 PY
 }
 
+pyroscope_has_expected_profile_services() {
+  local now start request response
+  now=$(date +%s)000
+  start=$(( $(date +%s) - 3600 ))000
+  request=$(printf '{"start":%s,"end":%s,"name":"service_name","matchers":[]}' "$start" "$now")
+  response=$(curl -fsS \
+    -H "Content-Type: application/json" \
+    -d "$request" \
+    "${PYROSCOPE_URL}/querier.v1.QuerierService/LabelValues")
+
+  RESPONSE="$response" EXPECTED_SERVICES="${EXPECTED_PROFILE_SERVICES[*]}" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = json.loads(os.environ["RESPONSE"])
+services = set(payload.get("names", []))
+expected = set(os.environ["EXPECTED_SERVICES"].split())
+missing = sorted(expected - services)
+if missing:
+    observed = sorted(service for service in services if service)
+    print("[diag] check=pyroscope_expected_profile_services status=missing_labels", file=sys.stderr)
+    print(f"[diag] expected_services={json.dumps(sorted(expected))}", file=sys.stderr)
+    print(f"[diag] observed_services={json.dumps(observed)}", file=sys.stderr)
+    print(f"[diag] missing_services={json.dumps(missing)}", file=sys.stderr)
+    sys.exit(f"Missing profile services: {', '.join(missing)}")
+PY
+}
+
 loki_has_recent_logs() {
   local response
   response=$(curl -fsS --get "${LOKI_URL}/loki/api/v1/query" \
@@ -270,6 +311,45 @@ for index, item in enumerate(result[:10]):
     print(f"[diag] series[{index}].value={item.get('value', [None, None])[1]}", file=sys.stderr)
 
 sys.exit("No recent Loki logs found")
+PY
+}
+
+loki_has_app_o11y_service_logs() {
+  local query response
+  query='sum by (service_name, service_namespace, deployment_environment) (count_over_time({service_namespace="home-monitoring", deployment_environment="homelab", service_name=~"prometheus|grafana|otel-collector|loki|tempo|pyroscope|alertmanager|node_exporter|blackbox_exporter|garmin_exporter"}[5m]))'
+  response=$(curl -fsS --get "${LOKI_URL}/loki/api/v1/query" \
+    --data-urlencode "query=${query}")
+
+  RESPONSE="$response" QUERY="$query" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = json.loads(os.environ["RESPONSE"])
+if payload.get("status") != "success":
+    print("[diag] check=loki_app_o11y_service_logs status=query_failed", file=sys.stderr)
+    print(f"[diag] response={json.dumps(payload, sort_keys=True)}", file=sys.stderr)
+    sys.exit("Loki query did not succeed")
+
+result = payload["data"]["result"]
+for item in result:
+    metric = item.get("metric", {})
+    if (
+        float(item["value"][1]) > 0
+        and metric.get("service_name")
+        and metric.get("service_namespace") == "home-monitoring"
+        and metric.get("deployment_environment") == "homelab"
+    ):
+        sys.exit(0)
+
+print("[diag] check=loki_app_o11y_service_logs status=no_positive_series", file=sys.stderr)
+print(f"[diag] query={os.environ['QUERY']}", file=sys.stderr)
+print(f"[diag] series_count={len(result)}", file=sys.stderr)
+for index, item in enumerate(result[:10]):
+    print(f"[diag] series[{index}].labels={json.dumps(item.get('metric', {}), sort_keys=True)}", file=sys.stderr)
+    print(f"[diag] series[{index}].value={item.get('value', [None, None])[1]}", file=sys.stderr)
+
+sys.exit("No recent Loki logs with App O11y service identity found")
 PY
 }
 
@@ -424,6 +504,7 @@ generate_activity
 
 wait_until "Prometheus has all expected collector-scraped jobs" "$TIMEOUT_SECONDS" prometheus_has_expected_jobs
 wait_until "Loki has recent stack logs" "$TIMEOUT_SECONDS" loki_has_recent_logs
+wait_until "Loki logs have App O11y service identity" "$TIMEOUT_SECONDS" loki_has_app_o11y_service_logs
 wait_until "Tempo has recent traces" "$TIMEOUT_SECONDS" tempo_has_recent_traces
 wait_until "Grafana can query the Prometheus datasource" "$TIMEOUT_SECONDS" grafana_datasource_is_healthy prometheus
 wait_until "Grafana can query the Loki datasource" "$TIMEOUT_SECONDS" grafana_datasource_is_healthy loki
@@ -440,5 +521,7 @@ wait_until "collector exports profiles to local Pyroscope" "$TIMEOUT_SECONDS" \
   prometheus_any_positive 'sum(rate(otelcol_exporter_sent_profile_samples_total{exporter="otlp_http/pyroscope"}[5m]))'
 wait_until "collector scrapes profiles from all expected services" "$TIMEOUT_SECONDS" \
   prometheus_has_expected_profile_receivers
+wait_until "Pyroscope has profiles from all expected services" "$TIMEOUT_SECONDS" \
+  pyroscope_has_expected_profile_services
 
 pass "local stack verification completed"


### PR DESCRIPTION
## Summary
- Add stable OpenTelemetry service identity to Docker logs for App O11y log correlation.
- Normalize the blackbox scrape job to `blackbox_exporter` and update dashboard log queries to use stable service names.
- Add shared environment/namespace metadata to profile pipelines and verify expected Pyroscope services locally.

## Test plan
- `bash -n scripts/verify-local-stack.sh`
- `docker compose config --quiet`
- `git diff --check`
- `./scripts/verify-local-stack.sh --no-start --timeout 300`


Made with [Cursor](https://cursor.com)