### PR TITLE
Build custom OpenTelemetry Collector distribution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+*/storage
+secrets/*
+opentelemetry-collector/_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */storage
 secrets/*
+opentelemetry-collector/_build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+OCB_VERSION ?= v0.152.1
+OTELCOL_BUILDER_CONFIG := opentelemetry-collector/builder-config.yaml
+OTELCOL_BUILD_DIR := opentelemetry-collector/_build
+
+.PHONY: otelcol-generate
+otelcol-generate:
+	go run go.opentelemetry.io/collector/cmd/builder@$(OCB_VERSION) --config=$(OTELCOL_BUILDER_CONFIG) --skip-compilation
+
+.PHONY: otelcol-build
+otelcol-build:
+	go run go.opentelemetry.io/collector/cmd/builder@$(OCB_VERSION) --config=$(OTELCOL_BUILDER_CONFIG)
+
+.PHONY: otelcol-check
+otelcol-check: otelcol-generate
+	cd $(OTELCOL_BUILD_DIR) && go build ./...
+
+.PHONY: otelcol-image
+otelcol-image:
+	docker compose build otel-collector
+
+.PHONY: otelcol-clean
+otelcol-clean:
+	rm -rf $(OTELCOL_BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,23 @@ It is intentionally small enough to run with Docker Compose, but complete enough
 | [Loki](https://github.com/grafana/loki) | Local logs backend. It receives logs from the collector through OTLP. |
 | [Tempo](https://github.com/grafana/tempo) | Local traces backend. It receives traces from the collector through OTLP. |
 | [Pyroscope](https://github.com/grafana/pyroscope) | Local profiles backend. It receives profiles from the collector through OTLP. |
-| [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) | Central telemetry pipeline for metrics, logs, traces, and profiles. |
+| [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) | Custom local distribution for the central telemetry pipeline for metrics, logs, traces, and profiles. |
 | [Alertmanager](https://github.com/prometheus/alertmanager) | Alert routing and tracing target. |
 | [Node Exporter](https://github.com/prometheus/node_exporter) | Host metrics. |
 | [Blackbox Exporter](https://github.com/prometheus/blackbox_exporter) | External endpoint probing. |
 | [Garmin Exporter](https://github.com/barnes-c/garmin_exporter) | Garmin Connect health and training metrics (scraped every 5m). |
 | Grafana Cloud | Remote metrics, logs, traces, and profiles for cloud dogfooding. |
+
+## Custom Collector
+
+The `otel-collector` Compose service builds a minimal OpenTelemetry Collector distribution from `opentelemetry-collector/builder-config.yaml`.
+
+Useful commands:
+
+```sh
+make otelcol-check
+make otelcol-image
+```
 
 ## Grafana Cloud Git Sync
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,10 @@ services:
       - "4040:4040"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.152.1@sha256:fa1f6ea8dabd3042fabf4411eed7fa52f253edd8940140bec89a573e62a24eb7
+    image: home-monitoring/otel-collector:0.152.1
+    build:
+      context: .
+      dockerfile: opentelemetry-collector/Dockerfile
     user: "0:0"
     restart: always # To re-read the configuration file
     command: ["--config=/etc/otel-collector-config.yaml", "--feature-gates=service.profilesSupport"]

--- a/opentelemetry-collector/Dockerfile
+++ b/opentelemetry-collector/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.25.4-bookworm AS builder
+
+ARG OCB_VERSION=v0.152.1
+
+WORKDIR /src
+
+COPY opentelemetry-collector/builder-config.yaml opentelemetry-collector/builder-config.yaml
+
+RUN go install go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION}
+RUN builder --config=opentelemetry-collector/builder-config.yaml
+
+FROM gcr.io/distroless/base-debian12:nonroot
+
+COPY --from=builder /src/opentelemetry-collector/_build/home-monitoring-otelcol /home-monitoring-otelcol
+
+ENTRYPOINT ["/home-monitoring-otelcol"]

--- a/opentelemetry-collector/builder-config.yaml
+++ b/opentelemetry-collector/builder-config.yaml
@@ -1,0 +1,37 @@
+dist:
+  module: github.com/arthursens/home-monitoring/cmd/home-monitoring-otelcol
+  name: home-monitoring-otelcol
+  description: Custom OpenTelemetry Collector distribution for the home monitoring stack.
+  output_path: ./opentelemetry-collector/_build
+  version: 0.152.1
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.152.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.152.0
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.152.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.152.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.152.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.152.1
+
+extensions:
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.152.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.152.0
+
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.58.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.58.0
+
+telemetry:
+  gomod: go.opentelemetry.io/collector/service v0.152.1
+  import: go.opentelemetry.io/collector/service/telemetry/otelconftelemetry

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,38 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Makefile$/",
+        "/^opentelemetry-collector\\/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "OCB_VERSION(?:\\s*\\?=|=)\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "go.opentelemetry.io/collector/cmd/builder",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^opentelemetry-collector\\/builder-config\\.yaml$/"
+      ],
+      "matchStrings": [
+        "gomod:\\s+(?<depName>[^\\s]+)\\s+(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "go"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "/^go\\.opentelemetry\\.io\\/collector/",
+        "/^github\\.com\\/open-telemetry\\/opentelemetry-collector-contrib/"
+      ],
+      "groupName": "opentelemetry collector"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Add an OCB builder config with only the collector components used by the local stack.
- Build a local `home-monitoring/otel-collector:0.152.1` image from Docker Compose.
- Configure Renovate to update OCB and builder config Go module versions together.

## Test plan
- `python3 -m json.tool renovate.json`
- `docker compose config --quiet`
- `make otelcol-check`
- `docker compose build otel-collector`
- `scripts/verify-local-stack.sh --timeout 900`

Made with [Cursor](https://cursor.com)