### PR TITLE
Configure Grafana Cloud host billing identifier

### DIFF
--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -219,6 +219,9 @@ processors:
   batch:
   resource/home_monitoring:
     attributes:
+      - key: grafana.host.id
+        value: homelab
+        action: insert
       - key: service.namespace
         value: home-monitoring
         action: insert


### PR DESCRIPTION
## Summary
- Add a stable `grafana.host.id` resource attribute for the homelab Docker host.
- Ensure telemetry exported to Grafana Cloud can be associated with the correct Application Observability billing host.

## Test plan
- Checked IDE diagnostics for `opentelemetry-collector/config.yaml`.


Made with [Cursor](https://cursor.com)