### PR TITLE
Test Garmin exporter login backoff image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - "9100:9100"
 
   garmin_exporter:
-    image: ghcr.io/barnes-c/garmin_exporter:0.1.2@sha256:61f10b7165c2b0f95a9f3a7892fdd28e4be176666a6645ec8c905fe125577911
+    image: garmin_exporter:login-backoff
     restart: unless-stopped
     env_file:
       - ./secrets/garmin.env


### PR DESCRIPTION
## Summary
- Switch `garmin_exporter` to the local `garmin_exporter:login-backoff` image for validating Garmin login rate-limit handling.
- Local logs showed the exporter staying up after 429s and spacing login retries out instead of retrying every few hundred milliseconds.

## Follow-up
Once https://github.com/barnes-c/garmin_exporter/pull/14 is merged and released, we can switch this back to the upstream `ghcr.io/barnes-c/garmin_exporter` image tag/digest.

## Test plan
- Deployed `garmin_exporter:login-backoff` locally with Docker Compose.
- Observed login failures backing off from `1m0s` to `1m29s` to `1m47s`.

Made with [Cursor](https://cursor.com)