### PR TITLE
Add hydration SLO alerting

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,67 @@
+name: Terraform
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Terraform
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Terraform changes
+        id: changes
+        run: |
+          pattern='^(\.github/workflows/terraform\.yml|terraform/.*)$'
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          else
+            if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+              changed_files="$(git diff --name-only HEAD^ HEAD)"
+            else
+              changed_files="$(git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}")"
+            fi
+          fi
+
+          if echo "$changed_files" | grep -Eq "$pattern"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Terraform-related files changed; running validation."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Terraform-related files changed; skipping validation."
+          fi
+
+      - name: Skip Terraform validation
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "Validation not required for this change set."
+
+      - name: Set up Terraform
+        if: steps.changes.outputs.changed == 'true'
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.13.5
+
+      - name: Check Terraform formatting
+        if: steps.changes.outputs.changed == 'true'
+        run: terraform -chdir=terraform/grafana fmt -check -diff
+
+      - name: Initialize Terraform
+        if: steps.changes.outputs.changed == 'true'
+        run: terraform -chdir=terraform/grafana init -backend=false -input=false
+
+      - name: Validate Terraform
+        if: steps.changes.outputs.changed == 'true'
+        run: terraform -chdir=terraform/grafana validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 */storage
 secrets/*
 opentelemetry-collector/_build/
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json

--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -1,0 +1,52 @@
+groups:
+- name: garmin
+  rules:
+
+  - record: garmin:hydration_target_ml
+    expr: garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml
+
+  - record: garmin:hydration_progress:ratio
+    expr: |
+      clamp_max(
+        garmin_hydration_intake_ml
+          / (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml)
+          and (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) > 0,
+        1
+      )
+
+  # Predict at lunchtime whether today's intake trend reaches the Garmin goal plus sweat loss.
+  - alert: HydrationBehindPace
+    expr: |
+      (
+        predict_linear(
+          garmin_hydration_intake_ml[3h],
+          scalar(
+            (24 - hour(vector(time() - 3 * 3600))) * 3600
+            - minute(vector(time() - 3 * 3600)) * 60
+          )
+        )
+          < garmin:hydration_target_ml
+      )
+        and garmin:hydration_target_ml > 0
+        and on() (hour(vector(time() - 3 * 3600)) >= 12)
+        and on() (hour(vector(time() - 3 * 3600)) < 21)
+    for: 30m
+    labels:
+      severity: warning
+      service: hydration
+      team: garmin-health
+    annotations:
+      description: "Hydration intake is not on track to reach today's Garmin goal plus sweat loss."
+
+  - alert: HydrationGoalMissed
+    expr: |
+      garmin_hydration_intake_ml < garmin:hydration_target_ml
+        and garmin:hydration_target_ml > 0
+        and on() (hour(vector(time() - 3 * 3600)) >= 21)
+    for: 30m
+    labels:
+      severity: critical
+      service: hydration
+      team: garmin-health
+    annotations:
+      description: "Hydration intake is still below today's Garmin goal plus sweat loss."

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,15 @@
         "/^github\\.com\\/open-telemetry\\/opentelemetry-collector-contrib/"
       ],
       "groupName": "opentelemetry collector"
+    },
+    {
+      "matchManagers": [
+        "terraform"
+      ],
+      "groupName": "terraform"
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }

--- a/terraform/grafana/.terraform.lock.hcl
+++ b/terraform/grafana/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.36.0"
+  constraints = ">= 3.15.3"
+  hashes = [
+    "h1:IGf/q6fe1lfhlZr1hs8638bT8Rpl/aVp+ods3Alv0lk=",
+    "zh:034dc829b9157784a5b2bc368f6fed92701e8fbf7aa5012ca8ae13b30016dbd1",
+    "zh:03fe8cdbc28e30c037a02632774d49215ad6ddfd658e91f106eb0db9770cfa37",
+    "zh:16e319ba0afa02d3e3c5ac9071eb755a25f27c37c3450c2754cabf9ebf1e8fe5",
+    "zh:1d04698fa45765c618f9c76c6002b9bdb59e7252e97f9eac54e0f513fd2cfad7",
+    "zh:2dab26c2ac5b9d48377e0a28537c1e4e52422915f9d01992af3267559dc6a64b",
+    "zh:33774fbb15c0e5bb82abcb4a5c6add4772030eba3137f736a24cabd9fe320cc1",
+    "zh:371a059fd520c990c6c6fc841135a788eb24318a1ed3899cc573587056ee3490",
+    "zh:48f1ad5a73c436d8db44b71c8f9ba7f55ca1079cec8a35644c60718feb812ecb",
+    "zh:56ccf8ca05289f20501c14a5667c8f30154474f0cbbd315d06a02d0f803d3637",
+    "zh:5f148ed5da6d24b4d23d1e503154d1330cfd888f2373440c04844a6320f4de44",
+    "zh:62dd36f02a10d6ddf2f82180a0015017c57e6040547ba0e4f621916ce11a96ad",
+    "zh:9661beb68a3affaa40179330318d6c860eb8bd94dc15a69cfba45098a4f8dbec",
+    "zh:970fcb2fdc429352b2352f8e15449256ff854daec13ca74fbd91c4e4250a962c",
+    "zh:9b8c2c04601a780ef3509ddbdd5df6c0dccbd094caed18ba3677569d6a68bad9",
+    "zh:a220990351f08021a41f90f365ac72ed144d44da9a78506270bcc5a4d41e4c42",
+    "zh:b357042597a6f46b7f0ec744a79723668e050a05ec751c08e438a87d0e419a98",
+    "zh:c882a326f50a582a6f7b0ac23451a442c2b07ab16abd17bf7292fa83da40ee90",
+    "zh:e3ca3abef73929270d9abbe97d34653f551c7599f4cd6730874b44b29dbf723a",
+    "zh:ffd9a5224a43ff2bc34c91ad11f192b2ebef495a8357586574ef8699f4789844",
+  ]
+}

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -1,0 +1,29 @@
+resource "grafana_contact_point" "hydration_slo_irm" {
+  name = "Hydration SLO IRM"
+
+  oncall {
+    url = grafana_oncall_integration.hydration_slo.link
+  }
+}
+
+resource "grafana_notification_policy" "default" {
+  contact_point = "grafana-default-email"
+  group_by      = ["grafana_folder", "alertname"]
+
+  policy {
+    matcher {
+      label = "service"
+      match = "="
+      value = "hydration"
+    }
+
+    matcher {
+      label = "team"
+      match = "="
+      value = "garmin-health"
+    }
+
+    contact_point = grafana_contact_point.hydration_slo_irm.name
+    group_by      = ["grafana_folder", "alertname"]
+  }
+}

--- a/terraform/grafana/hydration_slo.tf
+++ b/terraform/grafana/hydration_slo.tf
@@ -1,0 +1,106 @@
+resource "grafana_slo" "hydration" {
+  name        = "Hydration daily target"
+  description = "Tracks whether daily Garmin hydration intake reaches the configured goal plus sweat loss."
+
+  query {
+    type = "freeform"
+
+    freeform {
+      query = <<-PROMQL
+        (
+          sum(
+            max_over_time(garmin_hydration_intake_ml[$__rate_interval])
+            >= bool
+            (
+              max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+              +
+              max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+            )
+          )
+          and on() (hour(vector(time() - 3 * 3600)) >= 21)
+        )
+        /
+        (
+          sum(
+            (
+              max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+              +
+              max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+            ) > bool 0
+          )
+          and on() (hour(vector(time() - 3 * 3600)) >= 21)
+        )
+        or
+        (
+          vector(1)
+          and on() (hour(vector(time() - 3 * 3600)) < 21)
+        )
+      PROMQL
+    }
+  }
+
+  objectives {
+    value  = var.hydration_slo_objective
+    window = var.hydration_slo_window
+  }
+
+  destination_datasource {
+    uid = var.prometheus_datasource_uid
+  }
+
+  label {
+    key   = "service"
+    value = "hydration"
+  }
+
+  label {
+    key   = "team"
+    value = "garmin-health"
+  }
+
+  alerting {
+    fastburn {
+      annotation {
+        key   = "name"
+        value = "Hydration SLO fast burn"
+      }
+
+      annotation {
+        key   = "description"
+        value = "Daily hydration target misses are burning the hydration SLO error budget quickly."
+      }
+
+      label {
+        key   = "service"
+        value = "hydration"
+      }
+
+      label {
+        key   = "team"
+        value = "garmin-health"
+      }
+    }
+
+    slowburn {
+      annotation {
+        key   = "name"
+        value = "Hydration SLO slow burn"
+      }
+
+      annotation {
+        key   = "description"
+        value = "Daily hydration target misses are gradually burning the hydration SLO error budget."
+      }
+
+      label {
+        key   = "service"
+        value = "hydration"
+      }
+
+      label {
+        key   = "team"
+        value = "garmin-health"
+      }
+    }
+  }
+}

--- a/terraform/grafana/irm.tf
+++ b/terraform/grafana/irm.tf
@@ -1,0 +1,108 @@
+resource "grafana_oncall_on_call_shift" "hydration_primary" {
+  provider = grafana.oncall
+
+  name       = "Hydration primary"
+  type       = "rolling_users"
+  start      = "2026-05-25T00:00:00"
+  duration   = 60 * 60 * 24
+  frequency  = "daily"
+  interval   = 1
+  time_zone  = "America/Sao_Paulo"
+  team_id    = data.grafana_oncall_team.garmin_health.id
+  week_start = "MO"
+  rolling_users = [
+    var.oncall_user_ids,
+  ]
+}
+
+resource "grafana_oncall_schedule" "hydration" {
+  provider = grafana.oncall
+
+  name      = "Hydration"
+  type      = "calendar"
+  time_zone = "America/Sao_Paulo"
+  team_id   = data.grafana_oncall_team.garmin_health.id
+  shifts = [
+    grafana_oncall_on_call_shift.hydration_primary.id,
+  ]
+}
+
+resource "grafana_oncall_escalation_chain" "hydration_warning" {
+  provider = grafana.oncall
+
+  name    = "Hydration warning"
+  team_id = data.grafana_oncall_team.garmin_health.id
+}
+
+resource "grafana_oncall_escalation" "hydration_warning_notify_schedule" {
+  provider = grafana.oncall
+
+  escalation_chain_id          = grafana_oncall_escalation_chain.hydration_warning.id
+  type                         = "notify_on_call_from_schedule"
+  notify_on_call_from_schedule = grafana_oncall_schedule.hydration.id
+  position                     = 0
+}
+
+resource "grafana_oncall_escalation_chain" "hydration_critical" {
+  provider = grafana.oncall
+
+  name    = "Hydration critical"
+  team_id = data.grafana_oncall_team.garmin_health.id
+}
+
+resource "grafana_oncall_escalation" "hydration_critical_notify_schedule" {
+  provider = grafana.oncall
+
+  escalation_chain_id          = grafana_oncall_escalation_chain.hydration_critical.id
+  type                         = "notify_on_call_from_schedule"
+  notify_on_call_from_schedule = grafana_oncall_schedule.hydration.id
+  important                    = true
+  position                     = 0
+}
+
+resource "grafana_oncall_escalation" "hydration_critical_wait" {
+  provider = grafana.oncall
+
+  escalation_chain_id = grafana_oncall_escalation_chain.hydration_critical.id
+  type                = "wait"
+  duration            = 300
+  position            = 1
+}
+
+resource "grafana_oncall_escalation" "hydration_critical_repeat" {
+  provider = grafana.oncall
+
+  escalation_chain_id = grafana_oncall_escalation_chain.hydration_critical.id
+  type                = "repeat_escalation"
+  position            = 2
+}
+
+resource "grafana_oncall_integration" "hydration_slo" {
+  provider = grafana.oncall
+
+  name    = "Hydration SLO"
+  type    = "grafana_alerting"
+  team_id = data.grafana_oncall_team.garmin_health.id
+
+  default_route {
+    escalation_chain_id = grafana_oncall_escalation_chain.hydration_warning.id
+  }
+}
+
+resource "grafana_oncall_route" "hydration_slo_warning" {
+  provider = grafana.oncall
+
+  integration_id      = grafana_oncall_integration.hydration_slo.id
+  escalation_chain_id = grafana_oncall_escalation_chain.hydration_warning.id
+  routing_regex       = "\"service\" *: *\"hydration\"[\\s\\S]*\"grafana_slo_severity\" *: *\"warning\""
+  position            = 0
+}
+
+resource "grafana_oncall_route" "hydration_slo_critical" {
+  provider = grafana.oncall
+
+  integration_id      = grafana_oncall_integration.hydration_slo.id
+  escalation_chain_id = grafana_oncall_escalation_chain.hydration_critical.id
+  routing_regex       = "\"service\" *: *\"hydration\"[\\s\\S]*\"grafana_slo_severity\" *: *\"critical\""
+  position            = 1
+}

--- a/terraform/grafana/providers.tf
+++ b/terraform/grafana/providers.tf
@@ -1,0 +1,11 @@
+provider "grafana" {
+  url  = var.grafana_url
+  auth = var.grafana_auth
+}
+
+provider "grafana" {
+  alias      = "oncall"
+  url        = var.grafana_url
+  auth       = var.grafana_auth
+  oncall_url = var.grafana_oncall_url
+}

--- a/terraform/grafana/team.tf
+++ b/terraform/grafana/team.tf
@@ -1,0 +1,10 @@
+resource "grafana_team" "garmin_health" {
+  name    = "garmin-health"
+  members = var.grafana_team_members
+}
+
+data "grafana_oncall_team" "garmin_health" {
+  provider = grafana.oncall
+
+  name = grafana_team.garmin_health.name
+}

--- a/terraform/grafana/variables.tf
+++ b/terraform/grafana/variables.tf
@@ -1,0 +1,44 @@
+variable "grafana_url" {
+  description = "Grafana Cloud stack URL."
+  type        = string
+}
+
+variable "grafana_auth" {
+  description = "Grafana Cloud service account token with SLO and IRM permissions."
+  type        = string
+  sensitive   = true
+}
+
+variable "grafana_oncall_url" {
+  description = "Grafana IRM API URL from Alerts & IRM > IRM > Settings > Admin & API."
+  type        = string
+}
+
+variable "prometheus_datasource_uid" {
+  description = "Grafana Cloud Prometheus datasource UID used by Grafana SLO."
+  type        = string
+  default     = "grafanacloud-prom"
+}
+
+variable "hydration_slo_window" {
+  description = "Grafana SLO objective window. Grafana SLO requires at least 7d."
+  type        = string
+  default     = "7d"
+}
+
+variable "hydration_slo_objective" {
+  description = "Fraction of days in the SLO window where hydration should reach the daily target."
+  type        = number
+  default     = 0.95
+}
+
+variable "oncall_user_ids" {
+  description = "Grafana IRM user IDs to include in the hydration on-call schedule."
+  type        = list(string)
+}
+
+variable "grafana_team_members" {
+  description = "Grafana user email addresses to include in the garmin-health team."
+  type        = set(string)
+  default     = ["arthur.silvasens@grafana.com"]
+}

--- a/terraform/grafana/versions.tf
+++ b/terraform/grafana/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = ">= 3.15.3"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add local Prometheus hydration recording and alert rules for Garmin intake versus goal plus sweat loss.
- Add Terraform-managed Grafana Cloud SLO, Alerting contact/policy routing, and IRM OnCall schedule/escalation resources for hydration.
- Add Terraform CI validation and ignore local Terraform state/tfvars files.

## Test plan
- docker run --rm --entrypoint=promtool -v "$PWD/prometheus/rules:/rules:ro" prom/prometheus:v3.11.3 check rules /rules/garmin-rules.yml /rules/myNotebook-rules.yml
- docker run --rm -v "$PWD/terraform/grafana:/workspace" -w /workspace hashicorp/terraform:1.13.5 fmt -check -diff
- docker run --rm -v "$PWD/terraform/grafana:/workspace" -w /workspace hashicorp/terraform:1.13.5 init -backend=false -input=false
- docker run --rm -v "$PWD/terraform/grafana:/workspace" -w /workspace hashicorp/terraform:1.13.5 validate
- Applied Terraform locally and verified Grafana Cloud SLO, contact point, notification policy, IRM integration, team, schedule, routes, and current on-call user with gcx.


Made with [Cursor](https://cursor.com)