### PR TITLE
Require Grafana team members variable

### DIFF
--- a/terraform/grafana/variables.tf
+++ b/terraform/grafana/variables.tf
@@ -40,5 +40,4 @@ variable "oncall_user_ids" {
 variable "grafana_team_members" {
   description = "Grafana user email addresses to include in the garmin-health team."
   type        = set(string)
-  default     = ["arthur.silvasens@grafana.com"]
 }


### PR DESCRIPTION
## Summary
- Remove the hard-coded Grafana team member email from the Terraform variable default.
- Require deployments to provide `grafana_team_members` explicitly via tfvars or another Terraform variable source.

## Test plan
- Not run: `terraform` is not installed in this environment.

Made with [Cursor](https://cursor.com)