### PR TITLE
Add hydration pace alert

### DIFF
--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -14,21 +14,21 @@ groups:
         1
       )
 
-  # Predict at lunchtime whether today's intake trend reaches the Garmin goal plus sweat loss.
+  # Predict whether today's intake trend reaches the Garmin goal plus sweat loss by 9 PM.
   - alert: HydrationBehindPace
     expr: |
       (
         predict_linear(
           garmin_hydration_intake_ml[3h],
           scalar(
-            (24 - hour(vector(time() - 3 * 3600))) * 3600
+            (21 - hour(vector(time() - 3 * 3600))) * 3600
             - minute(vector(time() - 3 * 3600)) * 60
           )
         )
           < garmin:hydration_target_ml
       )
         and garmin:hydration_target_ml > 0
-        and on() (hour(vector(time() - 3 * 3600)) >= 12)
+        and on() (hour(vector(time() - 3 * 3600)) >= 8)
         and on() (hour(vector(time() - 3 * 3600)) < 21)
     for: 30m
     labels:

--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -19,7 +19,7 @@ groups:
     expr: |
       (
         predict_linear(
-          garmin_hydration_intake_ml[3h],
+          garmin_hydration_intake_ml[6h],
           scalar(
             (21 - hour(vector(time() - 3 * 3600))) * 3600
             - minute(vector(time() - 3 * 3600)) * 60

--- a/terraform/grafana/.terraform.lock.hcl
+++ b/terraform/grafana/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/grafana/grafana" {
   constraints = ">= 3.15.3"
   hashes = [
     "h1:IGf/q6fe1lfhlZr1hs8638bT8Rpl/aVp+ods3Alv0lk=",
+    "h1:diC8smCrRmQIXL3rTjOVqHbq0L1unBENgJj3nazMcz0=",
     "zh:034dc829b9157784a5b2bc368f6fed92701e8fbf7aa5012ca8ae13b30016dbd1",
     "zh:03fe8cdbc28e30c037a02632774d49215ad6ddfd658e91f106eb0db9770cfa37",
     "zh:16e319ba0afa02d3e3c5ac9071eb755a25f27c37c3450c2754cabf9ebf1e8fe5",

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -1,3 +1,119 @@
+resource "grafana_folder" "hydration_alerts" {
+  title = "Hydration"
+}
+
+resource "grafana_rule_group" "hydration_pace" {
+  name             = "Hydration pace"
+  folder_uid       = grafana_folder.hydration_alerts.uid
+  interval_seconds = 60
+
+  rule {
+    name           = "Hydration behind pace"
+    condition      = "C"
+    for            = "30m"
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+    is_paused      = false
+
+    annotations = {
+      description = "Hydration intake is not on track to reach today's Garmin goal plus sweat loss by 9 PM."
+      summary     = "Hydration is behind pace"
+    }
+
+    labels = {
+      service  = "hydration"
+      severity = "warning"
+      team     = "garmin-health"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = var.prometheus_datasource_uid
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      model = jsonencode({
+        datasource = {
+          type = "prometheus"
+          uid  = var.prometheus_datasource_uid
+        }
+        editorMode    = "code"
+        expr          = <<-PROMQL
+          (
+            predict_linear(
+              garmin_hydration_intake_ml[3h],
+              scalar(
+                (21 - hour(vector(time() - 3 * 3600))) * 3600
+                - minute(vector(time() - 3 * 3600)) * 60
+              )
+            )
+              < bool (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml)
+          )
+            and (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) > 0
+            and on() (hour(vector(time() - 3 * 3600)) >= 8)
+            and on() (hour(vector(time() - 3 * 3600)) < 21)
+        PROMQL
+        hide          = false
+        instant       = true
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        range         = false
+        refId         = "A"
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      model = jsonencode({
+        datasource = {
+          type = "__expr__"
+          uid  = "__expr__"
+        }
+        expression    = "A"
+        hide          = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        reducer       = "last"
+        refId         = "B"
+        type          = "reduce"
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      model = jsonencode({
+        datasource = {
+          type = "__expr__"
+          uid  = "__expr__"
+        }
+        expression    = "$B > 0"
+        hide          = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        refId         = "C"
+        type          = "math"
+      })
+    }
+  }
+}
+
 resource "grafana_contact_point" "hydration_slo_irm" {
   name = "Hydration SLO IRM"
 

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -31,7 +31,7 @@ resource "grafana_rule_group" "hydration_pace" {
       datasource_uid = var.prometheus_datasource_uid
 
       relative_time_range {
-        from = 10800
+        from = 21600
         to   = 0
       }
 
@@ -44,7 +44,7 @@ resource "grafana_rule_group" "hydration_pace" {
         expr          = <<-PROMQL
           (
             predict_linear(
-              garmin_hydration_intake_ml[3h],
+              garmin_hydration_intake_ml[6h],
               scalar(
                 (21 - hour(vector(time() - 3 * 3600))) * 3600
                 - minute(vector(time() - 3 * 3600)) * 60


### PR DESCRIPTION
## Summary
- Project hydration pace to 9 PM and start local pace checks at 8 AM.
- Add a Grafana Cloud managed alert that routes through the existing hydration IRM policy.

## Test plan
- terraform fmt -check -recursive terraform/grafana
- terraform validate
- terraform apply -auto-approve

Made with [Cursor](https://cursor.com)