### PR TITLE
Make hydration pace alert critical

### DIFF
--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -32,7 +32,7 @@ groups:
         and on() (hour(vector(time() - 3 * 3600)) < 21)
     for: 30m
     labels:
-      severity: warning
+      severity: critical
       service: hydration
       team: garmin-health
     annotations:

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -22,7 +22,7 @@ resource "grafana_rule_group" "hydration_pace" {
 
     labels = {
       service  = "hydration"
-      severity = "warning"
+      severity = "critical"
       team     = "garmin-health"
     }
 


### PR DESCRIPTION
## Summary
- Change the hydration pace alert severity from warning to critical in local Prometheus rules.
- Update the Grafana Cloud managed hydration pace alert label to match.

## Test plan
- terraform fmt -check -recursive terraform/grafana
- terraform validate
- terraform apply -auto-approve

Made with [Cursor](https://cursor.com)