### PR TITLE
Route critical hydration alerts as important

### DIFF
--- a/terraform/grafana/irm.tf
+++ b/terraform/grafana/irm.tf
@@ -94,7 +94,8 @@ resource "grafana_oncall_route" "hydration_slo_warning" {
 
   integration_id      = grafana_oncall_integration.hydration_slo.id
   escalation_chain_id = grafana_oncall_escalation_chain.hydration_warning.id
-  routing_regex       = "\"service\" *: *\"hydration\"[\\s\\S]*\"grafana_slo_severity\" *: *\"warning\""
+  routing_type        = "jinja2"
+  routing_regex       = "{{ labels.service == \"hydration\" and labels.grafana_slo_severity == \"warning\" }}"
   position            = 0
 }
 
@@ -103,6 +104,7 @@ resource "grafana_oncall_route" "hydration_slo_critical" {
 
   integration_id      = grafana_oncall_integration.hydration_slo.id
   escalation_chain_id = grafana_oncall_escalation_chain.hydration_critical.id
-  routing_regex       = "\"service\" *: *\"hydration\"[\\s\\S]*\"grafana_slo_severity\" *: *\"critical\""
+  routing_type        = "jinja2"
+  routing_regex       = "{{ labels.service == \"hydration\" and (labels.grafana_slo_severity == \"critical\" or labels.severity == \"critical\") }}"
   position            = 1
 }


### PR DESCRIPTION
## Summary
- Route hydration IRM alerts with Jinja templates instead of payload regex matching.
- Send normal Grafana alerts labeled `severity=critical` through the critical escalation chain so Important notification rules apply.

## Test plan
- `terraform fmt -check -diff && terraform validate`
- `terraform apply tfplan`
- `gcx irm oncall routes get RRC4LUW2F7239 -o json`
- `gcx irm oncall routes get R7JI729MTVL12 -o json`


Made with [Cursor](https://cursor.com)