### PR TITLE
Update hydration SLO budget timing

### DIFF
--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -37,16 +37,3 @@ groups:
       team: garmin-health
     annotations:
       description: "Hydration intake is not on track to reach today's Garmin goal plus sweat loss."
-
-  - alert: HydrationGoalMissed
-    expr: |
-      garmin_hydration_intake_ml < garmin:hydration_target_ml
-        and garmin:hydration_target_ml > 0
-        and on() (hour(vector(time() - 3 * 3600)) >= 21)
-    for: 30m
-    labels:
-      severity: critical
-      service: hydration
-      team: garmin-health
-    annotations:
-      description: "Hydration intake is still below today's Garmin goal plus sweat loss."

--- a/terraform/grafana/hydration_slo.tf
+++ b/terraform/grafana/hydration_slo.tf
@@ -1,3 +1,52 @@
+locals {
+  hydration_slo_utc_offset_seconds = 3 * 3600
+
+  hydration_slo_daily_ratio_query = <<-PROMQL
+    (
+      sum(
+        max_over_time(garmin_hydration_intake_ml[$__rate_interval])
+        >= bool
+        (
+          max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+          +
+          max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+        )
+      )
+      /
+      sum(
+        (
+          max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+          +
+          max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+        ) > bool 0
+      )
+    )
+    and on()
+    sum(
+      (
+        max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+        +
+        max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+      ) > bool 0
+    ) > 0
+  PROMQL
+
+  hydration_slo_previous_day_query = join("\n        or\n", [
+    for local_hour in range(24) : <<-PROMQL
+      (
+        last_over_time(
+          (
+            ${indent(8, local.hydration_slo_daily_ratio_query)}
+            and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) >= 23)
+            and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) < 24)
+          )[2h:1m] offset ${local_hour}h
+        )
+        and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) == ${local_hour})
+      )
+    PROMQL
+  ])
+}
+
 resource "grafana_slo" "hydration" {
   name        = "Hydration daily target"
   description = "Tracks whether daily Garmin hydration intake reaches the configured goal plus sweat loss."
@@ -7,34 +56,8 @@ resource "grafana_slo" "hydration" {
 
     freeform {
       query = <<-PROMQL
-        (
-          sum(
-            max_over_time(garmin_hydration_intake_ml[$__rate_interval])
-            >= bool
-            (
-              max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-              +
-              max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
-            )
-          )
-          and on() (hour(vector(time() - 3 * 3600)) >= 21)
-        )
-        /
-        (
-          sum(
-            (
-              max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-              +
-              max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
-            ) > bool 0
-          )
-          and on() (hour(vector(time() - 3 * 3600)) >= 21)
-        )
-        or
-        (
-          vector(1)
-          and on() (hour(vector(time() - 3 * 3600)) < 21)
-        )
+        ${indent(8, local.hydration_slo_previous_day_query)}
+        or vector(1)
       PROMQL
     }
   }

--- a/terraform/grafana/variables.tf
+++ b/terraform/grafana/variables.tf
@@ -21,9 +21,9 @@ variable "prometheus_datasource_uid" {
 }
 
 variable "hydration_slo_window" {
-  description = "Grafana SLO objective window. Grafana SLO requires at least 7d."
+  description = "Grafana SLO objective window."
   type        = string
-  default     = "7d"
+  default     = "30d"
 }
 
 variable "hydration_slo_objective" {


### PR DESCRIPTION
## Summary
- Change the Hydration SLO to use a 30-day window.
- Make today's SLO burn behavior depend on yesterday's completed local-day hydration result.
- Remove the local `HydrationGoalMissed` Prometheus alert now that the SLO owns missed-goal tracking.

## Test plan
- `terraform -chdir=terraform/grafana fmt`
- `terraform -chdir=terraform/grafana validate`
- `terraform -chdir=terraform/grafana apply -auto-approve`
- IDE lints clean


Made with [Cursor](https://cursor.com)