### PR TITLE
Update hydration pace alert start time

### DIFF
--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -28,7 +28,7 @@ groups:
           < garmin:hydration_target_ml
       )
         and garmin:hydration_target_ml > 0
-        and on() (hour(vector(time() - 3 * 3600)) >= 8)
+        and on() (hour(vector(time() - 3 * 3600)) >= 7)
         and on() (hour(vector(time() - 3 * 3600)) < 21)
     for: 30m
     labels:


### PR DESCRIPTION
## Summary
- Start the `HydrationBehindPace` alert window at 7AM local time instead of 8AM.

## Test plan
- `docker compose exec -T prometheus promtool check rules /etc/prometheus/rules/garmin-rules.yml`
- `curl -fsS -X POST http://localhost:81/-/reload`

Made with [Cursor](https://cursor.com)