### PR TITLE
Add configuration validation workflow

### DIFF
--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -1,0 +1,94 @@
+name: Configuration Validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Prometheus and collector configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect configuration changes
+        id: changes
+        run: |
+          pattern='^(\.github/workflows/config-validation\.yml|docker-compose\.yml|prometheus/prometheus\.yml|prometheus/rules/.*\.ya?ml|opentelemetry-collector/.*)$'
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          else
+            if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+              changed_files="$(git diff --name-only HEAD^ HEAD)"
+            else
+              changed_files="$(git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}")"
+            fi
+          fi
+
+          if echo "$changed_files" | grep -Eq "$pattern"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Configuration-related files changed; running validation."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No configuration-related files changed; skipping validation."
+          fi
+
+      - name: Skip configuration validation
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "Validation not required for this change set."
+
+      - name: Create local placeholder secret files
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          mkdir -p secrets
+          printf 'local-ci-placeholder\n' > secrets/grafana-cloud-instance-id
+          printf 'local-ci-placeholder\n' > secrets/grafana-cloud-api-token
+          printf 'admin\n' > secrets/grafana-admin-password
+          printf '%s\n' \
+            'GARMIN_USERNAME=local-ci-placeholder' \
+            'GARMIN_PASSWORD=local-ci-placeholder' \
+            > secrets/garmin.env
+
+      - name: Validate Compose configuration
+        if: steps.changes.outputs.changed == 'true'
+        run: docker compose config --quiet
+
+      - name: Validate Prometheus configuration
+        if: steps.changes.outputs.changed == 'true'
+        run: docker compose run --rm --no-deps --entrypoint promtool prometheus check config /etc/prometheus/prometheus.yml
+
+      - name: Validate Prometheus rules
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          rule_files=()
+          for rule_file in prometheus/rules/*.yml prometheus/rules/*.yaml; do
+            [ -e "$rule_file" ] || continue
+            rule_files+=("/etc/prometheus/rules/$(basename "$rule_file")")
+          done
+
+          if [ "${#rule_files[@]}" -eq 0 ]; then
+            echo "No Prometheus rule files found."
+            exit 0
+          fi
+
+          docker compose run --rm --no-deps --entrypoint promtool prometheus check rules "${rule_files[@]}"
+
+      - name: Build collector image
+        if: steps.changes.outputs.changed == 'true'
+        run: docker compose build otel-collector
+
+      - name: Validate collector configuration
+        if: steps.changes.outputs.changed == 'true'
+        run: docker compose run --rm --no-deps otel-collector validate --config=/etc/otel-collector-config.yaml --feature-gates=service.profilesSupport


### PR DESCRIPTION
## Summary
- Add a focused CI workflow for Prometheus and OpenTelemetry Collector configuration changes.
- Validate Compose config, Prometheus config/rules, and collector config before the full local stack job.

## Test plan
- docker compose config --quiet
- docker compose run --rm --no-deps --entrypoint promtool prometheus check config /etc/prometheus/prometheus.yml
- docker compose run --rm --no-deps --entrypoint promtool prometheus check rules /etc/prometheus/rules/garmin-rules.yml /etc/prometheus/rules/myNotebook-rules.yml
- docker compose build otel-collector
- docker compose run --rm --no-deps otel-collector validate --config=/etc/otel-collector-config.yaml --feature-gates=service.profilesSupport

Made with [Cursor](https://cursor.com)