### PR TITLE
Update hydration pace alert timing

### DIFF
--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -30,7 +30,6 @@ groups:
         and garmin:hydration_target_ml > 0
         and on() (hour(vector(time() - 3 * 3600)) >= 7)
         and on() (hour(vector(time() - 3 * 3600)) < 21)
-    for: 30m
     labels:
       severity: critical
       service: hydration

--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -14,14 +14,14 @@ groups:
         1
       )
 
-  # Predict whether today's intake trend reaches the Garmin goal plus sweat loss by 9 PM.
+  # Predict whether today's intake trend reaches the Garmin goal plus sweat loss by 7 PM.
   - alert: HydrationBehindPace
     expr: |
       (
         predict_linear(
           garmin_hydration_intake_ml[6h],
           scalar(
-            (21 - hour(vector(time() - 3 * 3600))) * 3600
+            (19 - hour(vector(time() - 3 * 3600))) * 3600
             - minute(vector(time() - 3 * 3600)) * 60
           )
         )
@@ -29,7 +29,7 @@ groups:
       )
         and garmin:hydration_target_ml > 0
         and on() (hour(vector(time() - 3 * 3600)) >= 7)
-        and on() (hour(vector(time() - 3 * 3600)) < 21)
+        and on() (hour(vector(time() - 3 * 3600)) < 19)
     labels:
       severity: critical
       service: hydration

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -10,13 +10,12 @@ resource "grafana_rule_group" "hydration_pace" {
   rule {
     name           = "Hydration behind pace"
     condition      = "C"
-    for            = "30m"
     no_data_state  = "OK"
     exec_err_state = "Error"
     is_paused      = false
 
     annotations = {
-      description = "Hydration intake is not on track to reach today's Garmin goal plus sweat loss by 9 PM."
+      description = "Hydration intake is not on track to reach today's Garmin goal plus sweat loss by 7 PM."
       summary     = "Hydration is behind pace"
     }
 
@@ -46,15 +45,15 @@ resource "grafana_rule_group" "hydration_pace" {
             predict_linear(
               garmin_hydration_intake_ml[6h],
               scalar(
-                (21 - hour(vector(time() - 3 * 3600))) * 3600
+                (19 - hour(vector(time() - 3 * 3600))) * 3600
                 - minute(vector(time() - 3 * 3600)) * 60
               )
             )
               < bool (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml)
           )
             and (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) > 0
-            and on() (hour(vector(time() - 3 * 3600)) >= 8)
-            and on() (hour(vector(time() - 3 * 3600)) < 21)
+            and on() (hour(vector(time() - 3 * 3600)) >= 7)
+            and on() (hour(vector(time() - 3 * 3600)) < 19)
         PROMQL
         hide          = false
         instant       = true


### PR DESCRIPTION
## Summary
- Remove the pending `for` duration from the local Prometheus and Terraform-managed Grafana Cloud hydration pace alerts.
- Update the hydration pace prediction deadline from 9 PM to 7 PM.
- Align the alert evaluation window to run from 7 AM until 7 PM in both local and Grafana Cloud rules.

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file("prometheus/rules/garmin-rules.yml"); puts "YAML OK"'`
- `terraform -chdir=terraform/grafana fmt -check -diff`
- Editor diagnostics: no linter errors for changed files
- Attempted `terraform -chdir=terraform/grafana validate`, but the Grafana provider package was not cached in `.terraform/providers`.
- Attempted `docker compose run --rm --no-deps --entrypoint promtool prometheus check rules /etc/prometheus/rules/garmin-rules.yml && curl -fsS -X POST http://localhost:81/-/reload`, but Docker failed before validation with `fork/exec /usr/bin/containerd-shim-runc-v2: exec format error`.