### PR TITLE
Fix hydration queries without sweat loss

### DIFF
--- a/grafana/provisioning/dashboards/home/garmin.json
+++ b/grafana/provisioning/dashboards/home/garmin.json
@@ -777,7 +777,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_hydration_intake_ml / (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) * 100",
+                        "expr": "garmin_hydration_intake_ml / ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml) * 100",
                         "instant": true,
                         "legendFormat": "Hydration %",
                         "queryType": "instant",
@@ -927,7 +927,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml",
+                        "expr": "(garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml",
                         "instant": true,
                         "legendFormat": "Goal + Sweat Loss",
                         "queryType": "instant",
@@ -950,7 +950,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml",
+                        "expr": "(garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml",
                         "instant": true,
                         "legendFormat": "Goal + Sweat Loss",
                         "queryType": "instant",

--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -3,14 +3,14 @@ groups:
   rules:
 
   - record: garmin:hydration_target_ml
-    expr: garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml
+    expr: (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml
 
   - record: garmin:hydration_progress:ratio
     expr: |
       clamp_max(
         garmin_hydration_intake_ml
-          / (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml)
-          and (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) > 0,
+          / garmin:hydration_target_ml
+          and garmin:hydration_target_ml > 0,
         1
       )
 

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -49,9 +49,9 @@ resource "grafana_rule_group" "hydration_pace" {
                 - minute(vector(time() - 3 * 3600)) * 60
               )
             )
-              < bool (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml)
+              < bool ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml)
           )
-            and (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) > 0
+            and ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml) > 0
             and on() (hour(vector(time() - 3 * 3600)) >= 7)
             and on() (hour(vector(time() - 3 * 3600)) < 19)
         PROMQL

--- a/terraform/grafana/hydration_slo.tf
+++ b/terraform/grafana/hydration_slo.tf
@@ -7,26 +7,38 @@ locals {
         max_over_time(garmin_hydration_intake_ml[$__rate_interval])
         >= bool
         (
+          (
+            max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+            +
+            max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+          )
+          or
           max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-          +
-          max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
         )
       )
       /
       sum(
         (
+          (
+            max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+            +
+            max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+          )
+          or
           max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-          +
-          max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
         ) > bool 0
       )
     )
     and on()
     sum(
       (
+        (
+          max_over_time(garmin_hydration_goal_ml[$__rate_interval])
+          +
+          max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
+        )
+        or
         max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-        +
-        max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
       ) > bool 0
     ) > 0
   PROMQL


### PR DESCRIPTION
## Summary
- Default hydration target queries to the Garmin goal when sweat loss metrics are absent.
- Reuse the local recording rule for hydration progress so rest days still produce data.
- Update dashboard, Grafana alerting, and SLO PromQL consistently.

## Test plan
- `docker compose config --quiet`
- `terraform fmt -check -diff terraform/grafana`
- `python3 -m json.tool grafana/provisioning/dashboards/home/garmin.json > /dev/null`
- `gcx resources validate --context arthursilvasens --on-error abort -p grafana/provisioning/dashboards/home`
- Not run: `promtool check rules` because Docker was unavailable and local `promtool` is not installed.

Made with [Cursor](https://cursor.com)