### PR TITLE
Validate Loki and Alertmanager configs in CI

### DIFF
--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Detect configuration changes
         id: changes
         run: |
-          pattern='^(\.github/workflows/config-validation\.yml|docker-compose\.yml|prometheus/prometheus\.yml|prometheus/rules/.*\.ya?ml|tempo/.*\.ya?ml|opentelemetry-collector/.*)$'
+          pattern='^(\.github/workflows/config-validation\.yml|docker-compose\.yml|alertmanager/.*\.ya?ml|loki/.*\.ya?ml|prometheus/prometheus\.yml|prometheus/rules/.*\.ya?ml|tempo/.*\.ya?ml|opentelemetry-collector/.*)$'
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
@@ -84,6 +84,14 @@ jobs:
           fi
 
           docker compose run --rm --no-deps --entrypoint promtool prometheus check rules "${rule_files[@]}"
+
+      - name: Validate Alertmanager configuration
+        if: steps.changes.outputs.changed == 'true'
+        run: docker compose run --rm --no-deps --entrypoint amtool alertmanager check-config /etc/alertmanager/alertmanager.yml
+
+      - name: Validate Loki configuration
+        if: steps.changes.outputs.changed == 'true'
+        run: docker compose run --rm --no-deps loki -config.file=/etc/loki/config.yaml -verify-config
 
       - name: Validate Tempo configuration
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- Add Alertmanager config validation with `amtool check-config`.
- Add Loki config validation with `loki -verify-config`.
- Run the configuration validation workflow for Alertmanager and Loki YAML changes.

## Test plan
- `docker compose config --quiet`
- `docker compose run --rm --no-deps --entrypoint amtool alertmanager check-config /etc/alertmanager/alertmanager.yml`
- `docker compose run --rm --no-deps loki -config.file=/etc/loki/config.yaml -verify-config`

Made with [Cursor](https://cursor.com)