### PR TITLE
Add homelab operations alerting

### DIFF
--- a/prometheus/rules/telemetry-pipeline-rules.yml
+++ b/prometheus/rules/telemetry-pipeline-rules.yml
@@ -1,0 +1,79 @@
+groups:
+- name: telemetry-pipeline
+  rules:
+
+  - alert: LokiWalDiskUsageHigh
+    expr: max(loki_ingester_wal_disk_usage_percent) > 0.85
+    for: 5m
+    labels:
+      severity: warning
+      service: loki
+      team: homelab-operations
+    annotations:
+      description: "Loki WAL disk usage is above 85%, close to the default 90% write-throttling threshold."
+      summary: "Loki WAL disk usage is close to capacity."
+
+  - alert: LokiWalDiskFullFailures
+    expr: increase(loki_ingester_wal_disk_full_failures_total[5m]) > 0
+    for: 1m
+    labels:
+      severity: critical
+      service: loki
+      team: homelab-operations
+    annotations:
+      description: "Loki reported WAL disk-full failures. Writes may be throttled or durability guarantees may be reduced."
+      summary: "Loki WAL hit disk-full protection."
+
+  - alert: OTelCollectorExporterQueueHigh
+    expr: |
+      (
+        sum by (exporter, data_type) (otelcol_exporter_queue_size)
+        /
+        sum by (exporter, data_type) (otelcol_exporter_queue_capacity)
+      ) > 0.7
+    for: 5m
+    labels:
+      severity: warning
+      service: otel-collector
+      team: homelab-operations
+    annotations:
+      description: "OpenTelemetry Collector exporter {{ $labels.exporter }} {{ $labels.data_type }} queue is above 70% capacity."
+      summary: "Collector exporter queue is filling."
+
+  - alert: OTelCollectorExporterQueueAlmostFull
+    expr: |
+      (
+        sum by (exporter, data_type) (otelcol_exporter_queue_size)
+        /
+        sum by (exporter, data_type) (otelcol_exporter_queue_capacity)
+      ) > 0.9
+    for: 2m
+    labels:
+      severity: critical
+      service: otel-collector
+      team: homelab-operations
+    annotations:
+      description: "OpenTelemetry Collector exporter {{ $labels.exporter }} {{ $labels.data_type }} queue is above 90% capacity. Data loss is likely if the destination does not recover."
+      summary: "Collector exporter queue is almost full."
+
+  - alert: OTelCollectorLogExportFailures
+    expr: sum by (exporter) (rate(otelcol_exporter_send_failed_log_records_total[5m])) > 0
+    for: 5m
+    labels:
+      severity: warning
+      service: otel-collector
+      team: homelab-operations
+    annotations:
+      description: "OpenTelemetry Collector exporter {{ $labels.exporter }} is failing to send log records."
+      summary: "Collector log export failures detected."
+
+  - alert: OTelCollectorLogEnqueueFailures
+    expr: sum by (exporter) (rate(otelcol_exporter_enqueue_failed_log_records_total[5m])) > 0
+    for: 1m
+    labels:
+      severity: critical
+      service: otel-collector
+      team: homelab-operations
+    annotations:
+      description: "OpenTelemetry Collector exporter {{ $labels.exporter }} failed to enqueue log records. The sending queue is likely full and log records are being dropped."
+      summary: "Collector is dropping logs before export."

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -2,6 +2,10 @@ resource "grafana_folder" "hydration_alerts" {
   title = "Hydration"
 }
 
+resource "grafana_folder" "homelab_operations_alerts" {
+  title = "Homelab Operations"
+}
+
 resource "grafana_rule_group" "hydration_pace" {
   name             = "Hydration pace"
   folder_uid       = grafana_folder.hydration_alerts.uid
@@ -113,11 +117,117 @@ resource "grafana_rule_group" "hydration_pace" {
   }
 }
 
+resource "grafana_rule_group" "loki_storage" {
+  name             = "Loki storage"
+  folder_uid       = grafana_folder.homelab_operations_alerts.uid
+  interval_seconds = 60
+
+  rule {
+    name           = "Loki WAL disk usage high"
+    condition      = "C"
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+    for            = "5m"
+    is_paused      = false
+
+    annotations = {
+      description = "Loki WAL disk usage is above 85%, close to the default 90% write-throttling threshold."
+      summary     = "Loki WAL disk usage is close to capacity"
+    }
+
+    labels = {
+      service  = "loki"
+      severity = "warning"
+      team     = "homelab-operations"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = var.prometheus_datasource_uid
+
+      relative_time_range {
+        from = 300
+        to   = 0
+      }
+
+      model = jsonencode({
+        datasource = {
+          type = "prometheus"
+          uid  = var.prometheus_datasource_uid
+        }
+        editorMode    = "code"
+        expr          = "max(loki_ingester_wal_disk_usage_percent)"
+        hide          = false
+        instant       = true
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        range         = false
+        refId         = "A"
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      model = jsonencode({
+        datasource = {
+          type = "__expr__"
+          uid  = "__expr__"
+        }
+        expression    = "A"
+        hide          = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        reducer       = "last"
+        refId         = "B"
+        type          = "reduce"
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      model = jsonencode({
+        datasource = {
+          type = "__expr__"
+          uid  = "__expr__"
+        }
+        expression    = "$B > 0.85"
+        hide          = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        refId         = "C"
+        type          = "math"
+      })
+    }
+  }
+}
+
 resource "grafana_contact_point" "hydration_slo_irm" {
   name = "Hydration SLO IRM"
 
   oncall {
     url = grafana_oncall_integration.hydration_slo.link
+  }
+}
+
+resource "grafana_contact_point" "homelab_operations_irm" {
+  name = "Homelab Operations IRM"
+
+  oncall {
+    url = grafana_oncall_integration.homelab_operations.link
   }
 }
 
@@ -139,6 +249,17 @@ resource "grafana_notification_policy" "default" {
     }
 
     contact_point = grafana_contact_point.hydration_slo_irm.name
+    group_by      = ["grafana_folder", "alertname"]
+  }
+
+  policy {
+    matcher {
+      label = "team"
+      match = "="
+      value = "homelab-operations"
+    }
+
+    contact_point = grafana_contact_point.homelab_operations_irm.name
     group_by      = ["grafana_folder", "alertname"]
   }
 }

--- a/terraform/grafana/collector_export_slo.tf
+++ b/terraform/grafana/collector_export_slo.tf
@@ -1,0 +1,136 @@
+locals {
+  collector_export_slos = {
+    metrics = {
+      display_name = "metric"
+      metric_name  = "metric_points"
+    }
+    traces = {
+      display_name = "trace"
+      metric_name  = "spans"
+    }
+    profiles = {
+      display_name = "profile"
+      metric_name  = "profiles"
+    }
+    logs = {
+      display_name = "log"
+      metric_name  = "log_records"
+    }
+  }
+}
+
+resource "grafana_slo" "collector_export" {
+  for_each = local.collector_export_slos
+
+  name        = "Collector ${each.value.display_name} export reliability"
+  description = "Tracks the fraction of ${each.value.display_name} telemetry items exported successfully by the home-monitoring collector."
+
+  query {
+    type = "freeform"
+
+    freeform {
+      query = <<-PROMQL
+        (
+          (
+            sum(rate(otelcol_exporter_sent_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval]))
+            /
+            (
+              sum(rate(otelcol_exporter_sent_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval]))
+              + (sum(rate(otelcol_exporter_send_failed_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval])) or vector(0))
+              + (sum(rate(otelcol_exporter_enqueue_failed_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval])) or vector(0))
+            )
+          )
+          unless
+          (
+            (
+              sum(rate(otelcol_exporter_sent_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval]))
+              + (sum(rate(otelcol_exporter_send_failed_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval])) or vector(0))
+              + (sum(rate(otelcol_exporter_enqueue_failed_${each.value.metric_name}_total{data_type="${each.key}"}[$__rate_interval])) or vector(0))
+            ) == 0
+          )
+        )
+        or vector(1)
+      PROMQL
+    }
+  }
+
+  objectives {
+    value  = var.collector_export_slo_objective
+    window = var.collector_export_slo_window
+  }
+
+  destination_datasource {
+    uid = var.prometheus_datasource_uid
+  }
+
+  label {
+    key   = "service"
+    value = "otel-collector"
+  }
+
+  label {
+    key   = "signal"
+    value = each.key
+  }
+
+  label {
+    key   = "team"
+    value = "homelab-operations"
+  }
+
+  alerting {
+    fastburn {
+      annotation {
+        key   = "name"
+        value = "Collector ${each.value.display_name} export SLO fast burn"
+      }
+
+      annotation {
+        key   = "description"
+        value = "Collector ${each.value.display_name} export failures are burning the homelab operations SLO error budget quickly."
+      }
+
+      label {
+        key   = "service"
+        value = "otel-collector"
+      }
+
+      label {
+        key   = "signal"
+        value = each.key
+      }
+
+      label {
+        key   = "team"
+        value = "homelab-operations"
+      }
+    }
+
+    slowburn {
+      annotation {
+        key   = "name"
+        value = "Collector ${each.value.display_name} export SLO slow burn"
+      }
+
+      annotation {
+        key   = "description"
+        value = "Collector ${each.value.display_name} export failures are gradually burning the homelab operations SLO error budget."
+      }
+
+      label {
+        key   = "service"
+        value = "otel-collector"
+      }
+
+      label {
+        key   = "signal"
+        value = each.key
+      }
+
+      label {
+        key   = "team"
+        value = "homelab-operations"
+      }
+    }
+  }
+}

--- a/terraform/grafana/irm.tf
+++ b/terraform/grafana/irm.tf
@@ -1,15 +1,14 @@
 resource "grafana_oncall_on_call_shift" "hydration_primary" {
   provider = grafana.oncall
 
-  name       = "Hydration primary"
-  type       = "rolling_users"
-  start      = "2026-05-25T00:00:00"
-  duration   = 60 * 60 * 24
-  frequency  = "daily"
-  interval   = 1
-  time_zone  = "America/Sao_Paulo"
-  team_id    = data.grafana_oncall_team.garmin_health.id
-  week_start = "MO"
+  name      = "Hydration primary"
+  type      = "rolling_users"
+  start     = "2026-05-25T00:00:00"
+  duration  = 60 * 60 * 24
+  frequency = "daily"
+  interval  = 1
+  time_zone = "America/Sao_Paulo"
+  team_id   = data.grafana_oncall_team.garmin_health.id
   rolling_users = [
     var.oncall_user_ids,
   ]
@@ -107,4 +106,124 @@ resource "grafana_oncall_route" "hydration_slo_critical" {
   routing_type        = "jinja2"
   routing_regex       = "{{ labels.service == \"hydration\" and (labels.grafana_slo_severity == \"critical\" or labels.severity == \"critical\") }}"
   position            = 1
+}
+
+resource "grafana_oncall_on_call_shift" "homelab_operations_primary" {
+  provider = grafana.oncall
+
+  name      = "Homelab operations primary"
+  type      = "rolling_users"
+  start     = "2026-06-01T00:00:00"
+  duration  = 60 * 60 * 24
+  frequency = "daily"
+  interval  = 1
+  time_zone = "America/Sao_Paulo"
+  team_id   = data.grafana_oncall_team.homelab_operations.id
+  rolling_users = [
+    var.homelab_ops_oncall_user_ids,
+  ]
+}
+
+resource "grafana_oncall_schedule" "homelab_operations" {
+  provider = grafana.oncall
+
+  name      = "Homelab operations"
+  type      = "calendar"
+  time_zone = "America/Sao_Paulo"
+  team_id   = data.grafana_oncall_team.homelab_operations.id
+  shifts = [
+    grafana_oncall_on_call_shift.homelab_operations_primary.id,
+  ]
+}
+
+resource "grafana_oncall_escalation_chain" "homelab_operations_warning" {
+  provider = grafana.oncall
+
+  name    = "Homelab operations warning"
+  team_id = data.grafana_oncall_team.homelab_operations.id
+}
+
+resource "grafana_oncall_escalation" "homelab_operations_warning_notify_schedule" {
+  provider = grafana.oncall
+
+  escalation_chain_id          = grafana_oncall_escalation_chain.homelab_operations_warning.id
+  type                         = "notify_on_call_from_schedule"
+  notify_on_call_from_schedule = grafana_oncall_schedule.homelab_operations.id
+  position                     = 0
+}
+
+resource "grafana_oncall_escalation_chain" "homelab_operations_critical" {
+  provider = grafana.oncall
+
+  name    = "Homelab operations critical"
+  team_id = data.grafana_oncall_team.homelab_operations.id
+}
+
+resource "grafana_oncall_escalation" "homelab_operations_critical_notify_schedule" {
+  provider = grafana.oncall
+
+  escalation_chain_id          = grafana_oncall_escalation_chain.homelab_operations_critical.id
+  type                         = "notify_on_call_from_schedule"
+  notify_on_call_from_schedule = grafana_oncall_schedule.homelab_operations.id
+  important                    = true
+  position                     = 0
+}
+
+resource "grafana_oncall_escalation" "homelab_operations_critical_wait" {
+  provider = grafana.oncall
+
+  escalation_chain_id = grafana_oncall_escalation_chain.homelab_operations_critical.id
+  type                = "wait"
+  duration            = 300
+  position            = 1
+}
+
+resource "grafana_oncall_escalation" "homelab_operations_critical_repeat" {
+  provider = grafana.oncall
+
+  escalation_chain_id = grafana_oncall_escalation_chain.homelab_operations_critical.id
+  type                = "repeat_escalation"
+  position            = 2
+}
+
+resource "grafana_oncall_integration" "homelab_operations" {
+  provider = grafana.oncall
+
+  name    = "Homelab operations"
+  type    = "grafana_alerting"
+  team_id = data.grafana_oncall_team.homelab_operations.id
+
+  default_route {
+    escalation_chain_id = grafana_oncall_escalation_chain.homelab_operations_warning.id
+  }
+}
+
+resource "grafana_oncall_route" "homelab_operations_warning" {
+  provider = grafana.oncall
+
+  integration_id      = grafana_oncall_integration.homelab_operations.id
+  escalation_chain_id = grafana_oncall_escalation_chain.homelab_operations_warning.id
+  routing_type        = "jinja2"
+  routing_regex       = "{{ labels.team == \"homelab-operations\" and labels.severity == \"warning\" }}"
+  position            = 0
+}
+
+resource "grafana_oncall_route" "homelab_operations_slo_warning" {
+  provider = grafana.oncall
+
+  integration_id      = grafana_oncall_integration.homelab_operations.id
+  escalation_chain_id = grafana_oncall_escalation_chain.homelab_operations_warning.id
+  routing_type        = "jinja2"
+  routing_regex       = "{{ labels.team == \"homelab-operations\" and labels.grafana_slo_severity == \"warning\" }}"
+  position            = 1
+}
+
+resource "grafana_oncall_route" "homelab_operations_critical" {
+  provider = grafana.oncall
+
+  integration_id      = grafana_oncall_integration.homelab_operations.id
+  escalation_chain_id = grafana_oncall_escalation_chain.homelab_operations_critical.id
+  routing_type        = "jinja2"
+  routing_regex       = "{{ labels.team == \"homelab-operations\" and (labels.grafana_slo_severity == \"critical\" or labels.severity == \"critical\") }}"
+  position            = 2
 }

--- a/terraform/grafana/team.tf
+++ b/terraform/grafana/team.tf
@@ -3,8 +3,19 @@ resource "grafana_team" "garmin_health" {
   members = var.grafana_team_members
 }
 
+resource "grafana_team" "homelab_operations" {
+  name    = "homelab-operations"
+  members = var.homelab_ops_team_members
+}
+
 data "grafana_oncall_team" "garmin_health" {
   provider = grafana.oncall
 
   name = grafana_team.garmin_health.name
+}
+
+data "grafana_oncall_team" "homelab_operations" {
+  provider = grafana.oncall
+
+  name = grafana_team.homelab_operations.name
 }

--- a/terraform/grafana/variables.tf
+++ b/terraform/grafana/variables.tf
@@ -32,12 +32,34 @@ variable "hydration_slo_objective" {
   default     = 0.95
 }
 
+variable "collector_export_slo_window" {
+  description = "Grafana SLO objective window for collector export reliability."
+  type        = string
+  default     = "30d"
+}
+
+variable "collector_export_slo_objective" {
+  description = "Fraction of collector telemetry items exported successfully in the SLO window."
+  type        = number
+  default     = 0.995
+}
+
 variable "oncall_user_ids" {
   description = "Grafana IRM user IDs to include in the hydration on-call schedule."
   type        = list(string)
 }
 
+variable "homelab_ops_oncall_user_ids" {
+  description = "Grafana IRM user IDs to include in the homelab operations on-call schedule."
+  type        = list(string)
+}
+
 variable "grafana_team_members" {
   description = "Grafana user email addresses to include in the garmin-health team."
+  type        = set(string)
+}
+
+variable "homelab_ops_team_members" {
+  description = "Grafana user email addresses to include in the homelab-operations team."
   type        = set(string)
 }


### PR DESCRIPTION
## Summary
- Add a homelab operations Grafana team, OnCall schedule, escalation routing, and IRM contact point.
- Add Grafana Cloud SLOs for collector export reliability across metrics, traces, profiles, and logs.
- Add local Prometheus alerts for Loki WAL pressure and collector log/export queue health.

## Test plan
- terraform fmt
- terraform validate
- terraform plan -detailed-exitcode
- docker compose run --rm --no-deps --entrypoint /bin/sh prometheus -c 'promtool check rules /etc/prometheus/rules/*.yml && promtool check config /etc/prometheus/prometheus.yml'
- Verified applied resources with gcx for SLOs, OnCall team/schedule/integration, contact point, and alert group.


Made with [Cursor](https://cursor.com)