### PR TITLE
Adjust Loki WAL alert threshold

### DIFF
--- a/loki/config.yaml
+++ b/loki/config.yaml
@@ -7,6 +7,10 @@ server:
 limits_config:
   allow_structured_metadata: true
 
+ingester:
+  wal:
+    disk_full_threshold: 0.98
+
 common:
   path_prefix: /loki
   storage:

--- a/prometheus/rules/telemetry-pipeline-rules.yml
+++ b/prometheus/rules/telemetry-pipeline-rules.yml
@@ -3,14 +3,14 @@ groups:
   rules:
 
   - alert: LokiWalDiskUsageHigh
-    expr: max(loki_ingester_wal_disk_usage_percent) > 0.85
+    expr: max(loki_ingester_wal_disk_usage_percent) > 0.95
     for: 5m
     labels:
       severity: warning
       service: loki
       team: homelab-operations
     annotations:
-      description: "Loki WAL disk usage is above 85%, close to the default 90% write-throttling threshold."
+      description: "Loki WAL disk usage is above 95%, close to the configured 98% write-throttling threshold."
       summary: "Loki WAL disk usage is close to capacity."
 
   - alert: LokiWalDiskFullFailures

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -131,7 +131,7 @@ resource "grafana_rule_group" "loki_storage" {
     is_paused      = false
 
     annotations = {
-      description = "Loki WAL disk usage is above 85%, close to the default 90% write-throttling threshold."
+      description = "Loki WAL disk usage is above 95%, close to the configured 98% write-throttling threshold."
       summary     = "Loki WAL disk usage is close to capacity"
     }
 
@@ -204,7 +204,7 @@ resource "grafana_rule_group" "loki_storage" {
           type = "__expr__"
           uid  = "__expr__"
         }
-        expression    = "$B > 0.85"
+        expression    = "$B > 0.95"
         hide          = false
         intervalMs    = 1000
         maxDataPoints = 43200


### PR DESCRIPTION
## Summary
- Raise Loki WAL disk-full threshold to 98%.
- Move local Prometheus and Grafana Cloud WAL warning alerts to 95%.
- Leave the disk-full failure alert unchanged for actual protection trips.

## Test plan
- Validated Loki config.
- Validated Prometheus rules and config.
- Validated Terraform formatting and configuration.
- Applied the Grafana Cloud alert change.
- Confirmed Terraform has no pending changes.
- Restarted local Loki and verified the live config reports disk_full_threshold: 0.98.
- Reloaded Prometheus and verified LokiWalDiskUsageHigh uses > 0.95 and is inactive.

Made with [Cursor](https://cursor.com)