### PR TITLE
Use blackhole Alertmanager receiver

### DIFF
--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -5,14 +5,11 @@ tracing:
   insecure: true
   sampling_fraction: 1.0
 route:
-  receiver: telegram-bot
+  receiver: blackhole
   group_by:
   - alertname
   group_wait: 10s
   group_interval: 10s
   repeat_interval: 1h
 receivers:
-- name: telegram-bot
-  webhook_configs:
-  - send_resolved: true
-    url: http://telegrambot:8080
+- name: blackhole


### PR DESCRIPTION
## Summary
- Replace the local Alertmanager default Telegram webhook receiver with a blackhole receiver.
- Avoid sending notifications to the nonexistent `telegrambot` service while still accepting alerts locally.

## Test plan
- `docker compose config --quiet`
- `docker compose run --rm --no-deps --entrypoint amtool alertmanager check-config /etc/alertmanager/alertmanager.yml`


Made with [Cursor](https://cursor.com)