### PR TITLE
Fix hydration SLO reset handling

### DIFF
--- a/terraform/grafana/hydration_slo.tf
+++ b/terraform/grafana/hydration_slo.tf
@@ -1,45 +1,46 @@
 locals {
   hydration_slo_utc_offset_seconds = 3 * 3600
+  hydration_slo_daily_window       = "18h"
+
+  hydration_slo_daily_intake_query = <<-PROMQL
+    max without (instance, service_instance_id) (
+      max_over_time(garmin_hydration_intake_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+    )
+  PROMQL
+
+  hydration_slo_daily_target_query = <<-PROMQL
+    (
+      (
+        max without (instance, service_instance_id) (
+          max_over_time(garmin_hydration_goal_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+        )
+        +
+        max without (instance, service_instance_id) (
+          max_over_time(garmin_hydration_sweat_loss_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+        )
+      )
+      or
+      max without (instance, service_instance_id) (
+        max_over_time(garmin_hydration_goal_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+      )
+    )
+  PROMQL
 
   hydration_slo_daily_ratio_query = <<-PROMQL
     (
       sum(
-        max_over_time(garmin_hydration_intake_ml[$__rate_interval])
+        ${indent(8, local.hydration_slo_daily_intake_query)}
         >= bool
-        (
-          (
-            max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-            +
-            max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
-          )
-          or
-          max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-        )
+        ${indent(8, local.hydration_slo_daily_target_query)}
       )
       /
       sum(
-        (
-          (
-            max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-            +
-            max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
-          )
-          or
-          max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-        ) > bool 0
+        ${indent(8, local.hydration_slo_daily_target_query)} > bool 0
       )
     )
     and on()
     sum(
-      (
-        (
-          max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-          +
-          max_over_time(garmin_hydration_sweat_loss_ml[$__rate_interval])
-        )
-        or
-        max_over_time(garmin_hydration_goal_ml[$__rate_interval])
-      ) > bool 0
+      ${indent(6, local.hydration_slo_daily_target_query)} > bool 0
     ) > 0
   PROMQL
 


### PR DESCRIPTION
## Summary
- Update the hydration SLO to evaluate the daily max intake over a bounded same-day window.
- Dedupe ephemeral Garmin exporter instance labels so stale/restarted exporters do not split one real hydration source.
- Applied the Terraform change to Grafana Cloud before opening this PR.

## Test plan
- `gcx metrics query --context arthursilvasens -d grafanacloud-prom ...` returned `1` for the reset-affected day.
- Local Prometheus query validated the bounded subquery syntax.
- `terraform fmt && terraform validate && terraform apply -auto-approve` completed successfully.


Made with [Cursor](https://cursor.com)