### PR TITLE
Tune Garmin exporter cache refresh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - ./secrets/garmin.env
     command:
       - --garmin.token-file=/data/garmin_token.json
+      - --cache.ttl=10m
     volumes:
       - garmin_data:/data
 

--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -25,8 +25,6 @@ receivers:
           static_configs:
             - targets: ['node_exporter:9100']
         - job_name: 'garmin_exporter'
-          scrape_interval: 5m
-          scrape_timeout: 2m
           static_configs:
             - targets: ['garmin_exporter:10045']
         - job_name: 'blackbox_exporter'


### PR DESCRIPTION
## Summary
- Set the Garmin exporter cache TTL explicitly so Garmin API refreshes are controlled by the exporter.
- Let the collector use its default scrape cadence for cached Garmin metrics.

## Test plan
- [x] docker compose config --quiet

Made with [Cursor](https://cursor.com)