### PR TITLE
Update hydration alert for Tokyo timezone

### DIFF
--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -43,21 +43,23 @@ resource "grafana_rule_group" "hydration_pace" {
           type = "prometheus"
           uid  = var.prometheus_datasource_uid
         }
-        editorMode    = "code"
+        editorMode = "code"
+        # PromQL time functions evaluate timestamps in UTC. Update this offset
+        # whenever the hydration alert should follow a different local timezone.
         expr          = <<-PROMQL
           (
             predict_linear(
               garmin_hydration_intake_ml[6h],
               scalar(
-                (19 - hour(vector(time() - 3 * 3600))) * 3600
-                - minute(vector(time() - 3 * 3600)) * 60
+                (19 - hour(vector(time() + 9 * 3600))) * 3600
+                - minute(vector(time() + 9 * 3600)) * 60
               )
             )
               < bool ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml)
           )
             and ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml) > 0
-            and on() (hour(vector(time() - 3 * 3600)) >= 7)
-            and on() (hour(vector(time() - 3 * 3600)) < 19)
+            and on() (hour(vector(time() + 9 * 3600)) >= 7)
+            and on() (hour(vector(time() + 9 * 3600)) < 19)
         PROMQL
         hide          = false
         instant       = true


### PR DESCRIPTION
## Summary
- Update the hydration pace PromQL time offset from Sao Paulo time to Tokyo time.
- Add a comment noting that PromQL time functions evaluate in UTC and the offset must be adjusted when the local timezone changes.
- Terraform has already been applied to Grafana Cloud for this alert rule update.

## Test plan
- terraform fmt -check
- terraform plan -out=tfplan
- terraform apply tfplan
- terraform plan -detailed-exitcode
- ReadLints on terraform/grafana/alerting.tf


Made with [Cursor](https://cursor.com)