### PR TITLE
Restore Brazil timezone for hydration alerts

### DIFF
--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -51,15 +51,15 @@ resource "grafana_rule_group" "hydration_pace" {
             predict_linear(
               garmin_hydration_intake_ml[6h],
               scalar(
-                (19 - hour(vector(time() + 9 * 3600))) * 3600
-                - minute(vector(time() + 9 * 3600)) * 60
+                (19 - hour(vector(time() - 3 * 3600))) * 3600
+                - minute(vector(time() - 3 * 3600)) * 60
               )
             )
               < bool ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml)
           )
             and ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml) > 0
-            and on() (hour(vector(time() + 9 * 3600)) >= 7)
-            and on() (hour(vector(time() + 9 * 3600)) < 19)
+            and on() (hour(vector(time() - 3 * 3600)) >= 7)
+            and on() (hour(vector(time() - 3 * 3600)) < 19)
         PROMQL
         hide          = false
         instant       = true

--- a/terraform/grafana/irm.tf
+++ b/terraform/grafana/irm.tf
@@ -7,7 +7,7 @@ resource "grafana_oncall_on_call_shift" "hydration_primary" {
   duration  = 60 * 60 * 24
   frequency = "daily"
   interval  = 1
-  time_zone = "Asia/Tokyo"
+  time_zone = "America/Sao_Paulo"
   team_id   = data.grafana_oncall_team.garmin_health.id
   rolling_users = [
     var.oncall_user_ids,
@@ -19,7 +19,7 @@ resource "grafana_oncall_schedule" "hydration" {
 
   name      = "Hydration"
   type      = "calendar"
-  time_zone = "Asia/Tokyo"
+  time_zone = "America/Sao_Paulo"
   team_id   = data.grafana_oncall_team.garmin_health.id
   shifts = [
     grafana_oncall_on_call_shift.hydration_primary.id,
@@ -117,7 +117,7 @@ resource "grafana_oncall_on_call_shift" "homelab_operations_primary" {
   duration  = 60 * 60 * 24
   frequency = "daily"
   interval  = 1
-  time_zone = "Asia/Tokyo"
+  time_zone = "America/Sao_Paulo"
   team_id   = data.grafana_oncall_team.homelab_operations.id
   rolling_users = [
     var.homelab_ops_oncall_user_ids,
@@ -129,7 +129,7 @@ resource "grafana_oncall_schedule" "homelab_operations" {
 
   name      = "Homelab operations"
   type      = "calendar"
-  time_zone = "Asia/Tokyo"
+  time_zone = "America/Sao_Paulo"
   team_id   = data.grafana_oncall_team.homelab_operations.id
   shifts = [
     grafana_oncall_on_call_shift.homelab_operations_primary.id,


### PR DESCRIPTION
## Summary
- restore hydration pace evaluation to UTC-3
- restore hydration and homelab IRM schedules to America/Sao_Paulo
- apply the five in-place updates to Grafana Cloud

## Test plan
- [x] `terraform fmt -check -diff`
- [x] `terraform validate`
- [x] `terraform plan -detailed-exitcode` reports no changes after apply

Made with [Cursor](https://cursor.com)