### PR TITLE
Fix hydration queries for OTLP metric names

### DIFF
--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Detect configuration changes
         id: changes
         run: |
-          pattern='^(\.github/workflows/config-validation\.yml|docker-compose\.yml|alertmanager/.*\.ya?ml|loki/.*\.ya?ml|prometheus/prometheus\.yml|prometheus/rules/.*\.ya?ml|tempo/.*\.ya?ml|opentelemetry-collector/.*)$'
+          pattern='^(\.github/workflows/config-validation\.yml|docker-compose\.yml|alertmanager/.*\.ya?ml|loki/.*\.ya?ml|prometheus/.*\.ya?ml|tempo/.*\.ya?ml|opentelemetry-collector/.*)$'
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
@@ -84,6 +84,15 @@ jobs:
           fi
 
           docker compose run --rm --no-deps --entrypoint promtool prometheus check rules "${rule_files[@]}"
+
+      - name: Test Prometheus rules
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          docker compose run --rm --no-deps \
+            -v "$PWD/prometheus:/workspace:ro" \
+            -w /workspace/tests \
+            --entrypoint promtool \
+            prometheus test rules garmin-rules.test.yml
 
       - name: Validate Alertmanager configuration
         if: steps.changes.outputs.changed == 'true'

--- a/grafana/provisioning/dashboards/home/garmin.json
+++ b/grafana/provisioning/dashboards/home/garmin.json
@@ -777,7 +777,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_hydration_intake_ml / ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml) * 100",
+                        "expr": "garmin_hydration_intake_ml_mL / ((garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL) * 100",
                         "instant": true,
                         "legendFormat": "Hydration %",
                         "queryType": "instant",
@@ -881,7 +881,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_hydration_intake_ml",
+                        "expr": "garmin_hydration_intake_ml_mL",
                         "instant": true,
                         "legendFormat": "Intake",
                         "queryType": "instant",
@@ -904,7 +904,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_hydration_goal_ml",
+                        "expr": "garmin_hydration_goal_ml_mL",
                         "instant": true,
                         "legendFormat": "Goal",
                         "queryType": "instant",
@@ -927,7 +927,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "(garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml",
+                        "expr": "(garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL",
                         "instant": true,
                         "legendFormat": "Goal + Sweat Loss",
                         "queryType": "instant",
@@ -950,7 +950,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "(garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml",
+                        "expr": "(garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL",
                         "instant": true,
                         "legendFormat": "Goal + Sweat Loss",
                         "queryType": "instant",

--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -3,12 +3,12 @@ groups:
   rules:
 
   - record: garmin:hydration_target_ml
-    expr: (garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml
+    expr: (garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL
 
   - record: garmin:hydration_progress:ratio
     expr: |
       clamp_max(
-        garmin_hydration_intake_ml
+        garmin_hydration_intake_ml_mL
           / garmin:hydration_target_ml
           and garmin:hydration_target_ml > 0,
         1
@@ -19,7 +19,7 @@ groups:
     expr: |
       (
         predict_linear(
-          garmin_hydration_intake_ml[6h],
+          garmin_hydration_intake_ml_mL[6h],
           scalar(
             (19 - hour(vector(time() - 3 * 3600))) * 3600
             - minute(vector(time() - 3 * 3600)) * 60

--- a/prometheus/tests/garmin-rules.test.yml
+++ b/prometheus/tests/garmin-rules.test.yml
@@ -1,0 +1,26 @@
+rule_files:
+  - ../rules/garmin-rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - name: hydration rules use OTLP unit-suffixed metrics
+    interval: 1m
+    input_series:
+      - series: garmin_hydration_intake_ml_mL
+        values: 500x10
+      - series: garmin_hydration_goal_ml_mL
+        values: 2500x10
+      - series: garmin_hydration_sweat_loss_ml_mL
+        values: 300x10
+    promql_expr_test:
+      - expr: garmin:hydration_target_ml
+        eval_time: 5m
+        exp_samples:
+          - labels: garmin:hydration_target_ml
+            value: 2800
+      - expr: garmin:hydration_progress:ratio
+        eval_time: 5m
+        exp_samples:
+          - labels: garmin:hydration_progress:ratio
+            value: 0.17857142857142858

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -49,15 +49,15 @@ resource "grafana_rule_group" "hydration_pace" {
         expr          = <<-PROMQL
           (
             predict_linear(
-              garmin_hydration_intake_ml[6h],
+              garmin_hydration_intake_ml_mL[6h],
               scalar(
                 (19 - hour(vector(time() - 3 * 3600))) * 3600
                 - minute(vector(time() - 3 * 3600)) * 60
               )
             )
-              < bool ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml)
+              < bool ((garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL)
           )
-            and ((garmin_hydration_goal_ml + garmin_hydration_sweat_loss_ml) or garmin_hydration_goal_ml) > 0
+            and ((garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL) > 0
             and on() (hour(vector(time() - 3 * 3600)) >= 7)
             and on() (hour(vector(time() - 3 * 3600)) < 19)
         PROMQL

--- a/terraform/grafana/hydration_slo.tf
+++ b/terraform/grafana/hydration_slo.tf
@@ -4,7 +4,7 @@ locals {
 
   hydration_slo_daily_intake_query = <<-PROMQL
     max without (instance, service_instance_id) (
-      max_over_time(garmin_hydration_intake_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+      max_over_time(garmin_hydration_intake_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
     )
   PROMQL
 
@@ -12,16 +12,16 @@ locals {
     (
       (
         max without (instance, service_instance_id) (
-          max_over_time(garmin_hydration_goal_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+          max_over_time(garmin_hydration_goal_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
         )
         +
         max without (instance, service_instance_id) (
-          max_over_time(garmin_hydration_sweat_loss_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+          max_over_time(garmin_hydration_sweat_loss_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
         )
       )
       or
       max without (instance, service_instance_id) (
-        max_over_time(garmin_hydration_goal_ml[${local.hydration_slo_daily_window}:$__rate_interval])
+        max_over_time(garmin_hydration_goal_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
       )
     )
   PROMQL


### PR DESCRIPTION
## Summary
- align hydration dashboard, recording rules, Cloud alert, and SLO queries with OTLP unit-suffixed Garmin metrics
- add promtool regression coverage for hydration target and progress rules
- run Prometheus rule tests in configuration validation CI

## Test plan
- [x] `promtool test rules prometheus/tests/garmin-rules.test.yml`
- [x] `promtool check rules prometheus/rules/garmin-rules.yml`
- [x] `terraform validate`
- [x] verify local Grafana provisioned the updated hydration queries
- [x] verify local Prometheus evaluates `garmin:hydration_target_ml`

Made with [Cursor](https://cursor.com)