### PR TITLE
Fix dashboard datasource selection

### DIFF
--- a/grafana/provisioning/dashboards/home/blackboxExporter.json
+++ b/grafana/provisioning/dashboards/home/blackboxExporter.json
@@ -827,7 +827,7 @@
           "multi": false,
           "options": [],
           "refresh": 1,
-          "regex": "",
+          "regex": "/(^Prometheus$|-prom$)/",
           "skipUrlSync": false
         },
         {
@@ -845,7 +845,7 @@
           "multi": false,
           "options": [],
           "refresh": 1,
-          "regex": "",
+          "regex": "/(^Loki$|-logs$)/",
           "skipUrlSync": false
         },
         {

--- a/grafana/provisioning/dashboards/home/garmin.json
+++ b/grafana/provisioning/dashboards/home/garmin.json
@@ -5971,7 +5971,7 @@
           "options": [],
           "pluginId": "prometheus",
           "refresh": "onDashboardLoad",
-          "regex": "",
+          "regex": "/(^Prometheus$|-prom$)/",
           "skipUrlSync": false
         }
       }

--- a/grafana/provisioning/dashboards/home/loki.json
+++ b/grafana/provisioning/dashboards/home/loki.json
@@ -2114,7 +2114,7 @@
             "name": "datasource",
             "pluginId": "prometheus",
             "refresh": "onDashboardLoad",
-            "regex": "",
+            "regex": "/(^Prometheus$|-prom$)/",
             "current": {
               "text": "",
               "value": ""
@@ -2134,7 +2134,7 @@
             "name": "loki_datasource",
             "pluginId": "loki",
             "refresh": "onDashboardLoad",
-            "regex": "",
+            "regex": "/(^Loki$|-logs$)/",
             "current": {
               "text": "",
               "value": ""

--- a/grafana/provisioning/dashboards/home/myNotebook.json
+++ b/grafana/provisioning/dashboards/home/myNotebook.json
@@ -3360,7 +3360,7 @@
           "options": [],
           "query": "prometheus",
           "refresh": 1,
-          "regex": "",
+          "regex": "/(^Prometheus$|-prom$)/",
           "skipUrlSync": false,
           "type": "datasource"
         },

--- a/grafana/provisioning/dashboards/home/opentelemetry-collector.json
+++ b/grafana/provisioning/dashboards/home/opentelemetry-collector.json
@@ -2257,7 +2257,7 @@
           "options": [],
           "pluginId": "prometheus",
           "refresh": "onDashboardLoad",
-          "regex": "",
+          "regex": "/(^Prometheus$|-prom$)/",
           "skipUrlSync": false
         }
       },
@@ -2277,7 +2277,7 @@
           "options": [],
           "pluginId": "loki",
           "refresh": "onDashboardLoad",
-          "regex": "",
+          "regex": "/(^Loki$|-logs$)/",
           "skipUrlSync": false
         }
       },

--- a/grafana/provisioning/dashboards/home/prometheus.json
+++ b/grafana/provisioning/dashboards/home/prometheus.json
@@ -2420,7 +2420,7 @@
             "name": "datasource",
             "pluginId": "prometheus",
             "refresh": "onDashboardLoad",
-            "regex": "",
+            "regex": "/(^Prometheus$|-prom$)/",
             "current": {
               "text": "Prometheus",
               "value": "prometheus"


### PR DESCRIPTION
## Summary
- filter Loki variables to select local Loki or the Grafana Cloud logs datasource
- filter Prometheus variables to exclude auxiliary Grafana Cloud datasources
- keep dashboard datasource selection portable between local and Cloud environments

## Test plan
- [x] Validate dashboard resources with `gcx resources validate`
- [x] Verify filters against local and Grafana Cloud datasource names
- [x] Check JSON files for lint and formatting errors

Made with [Cursor](https://cursor.com)