### PR TITLE
Support multiple Garmin accounts

### DIFF
--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -59,7 +59,11 @@ jobs:
           printf '%s\n' \
             'GARMIN_USERNAME=local-ci-placeholder' \
             'GARMIN_PASSWORD=local-ci-placeholder' \
-            > secrets/garmin.env
+            > secrets/garmin-arthur.env
+          printf '%s\n' \
+            'GARMIN_USERNAME=local-ci-placeholder' \
+            'GARMIN_PASSWORD=local-ci-placeholder' \
+            > secrets/garmin-julia.env
 
       - name: Validate Compose configuration
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/local-stack.yml
+++ b/.github/workflows/local-stack.yml
@@ -30,7 +30,11 @@ jobs:
           printf '%s\n' \
             'GARMIN_USERNAME=local-ci-placeholder' \
             'GARMIN_PASSWORD=local-ci-placeholder' \
-            > secrets/garmin.env
+            > secrets/garmin-arthur.env
+          printf '%s\n' \
+            'GARMIN_USERNAME=local-ci-placeholder' \
+            'GARMIN_PASSWORD=local-ci-placeholder' \
+            > secrets/garmin-julia.env
 
       - name: Prepare local storage directories
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,16 +80,31 @@ services:
     ports: 
       - "9100:9100"
 
-  garmin_exporter:
+  garmin_exporter_arthur:
     image: ghcr.io/barnes-c/garmin_exporter:1.1.1@sha256:49952d346cb0a2ce13e661c0a849ae5511dee7de2108caeca7f73bf4516d5c83
     restart: unless-stopped
+    environment:
+      - OTEL_SERVICE_NAME=garmin_exporter_arthur
     env_file:
-      - ./secrets/garmin.env
+      - ./secrets/garmin-arthur.env
     command:
       - --token-file=/data/garmin_token.json
       - --cache.ttl=10m
     volumes:
       - garmin_data:/data
+
+  garmin_exporter_julia:
+    image: ghcr.io/barnes-c/garmin_exporter:1.1.1@sha256:49952d346cb0a2ce13e661c0a849ae5511dee7de2108caeca7f73bf4516d5c83
+    restart: unless-stopped
+    environment:
+      - OTEL_SERVICE_NAME=garmin_exporter_julia
+    env_file:
+      - ./secrets/garmin-julia.env
+    command:
+      - --token-file=/data/garmin_token.json
+      - --cache.ttl=10m
+    volumes:
+      - garmin_data_julia:/data
 
   blackbox_exporter: 
     image: prom/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
@@ -142,10 +157,12 @@ services:
       - grafana_cloud_instance_id
       - grafana_cloud_api_token
     depends_on:
-      - garmin_exporter
+      - garmin_exporter_arthur
+      - garmin_exporter_julia
       - loki
       - tempo
       - pyroscope
 
 volumes:
   garmin_data:
+  garmin_data_julia:

--- a/grafana/provisioning/dashboards/home/garmin.json
+++ b/grafana/provisioning/dashboards/home/garmin.json
@@ -13,7 +13,7 @@
           "enable": true,
           "hide": true,
           "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations \u0026 Alerts",
+          "name": "Annotations & Alerts",
           "query": {
             "group": "grafana",
             "kind": "DataQuery",
@@ -24,7 +24,7 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "Personal health and fitness metrics from Garmin wearable — steps, heart rate, sleep, HRV, stress, SpO2, and activity.",
+    "description": "Personal health and fitness metrics from Garmin wearable \u2014 steps, heart rate, sleep, HRV, stress, SpO2, and activity.",
     "editable": true,
     "elements": {
       "panel-100": {
@@ -46,7 +46,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_high_stress_duration_seconds",
+                        "expr": "garmin_wellness_high_stress_duration_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "High Stress",
                         "queryType": "instant",
@@ -69,7 +69,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_avg_stress_duration_seconds",
+                        "expr": "garmin_wellness_avg_stress_duration_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Avg Stress",
                         "queryType": "instant",
@@ -92,7 +92,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_low_stress_duration_seconds",
+                        "expr": "garmin_wellness_low_stress_duration_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Low Stress",
                         "queryType": "instant",
@@ -115,7 +115,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_rest_stress_duration_seconds",
+                        "expr": "garmin_wellness_rest_stress_duration_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Rest",
                         "queryType": "instant",
@@ -131,7 +131,7 @@
               "transformations": []
             }
           },
-          "description": "Time spent in each stress zone throughout the day. Extended time in medium (51–75) or high (76–100) stress zones impairs HRV, sleep onset, and next-day recovery capacity.",
+          "description": "Time spent in each stress zone throughout the day. Extended time in medium (51\u201375) or high (76\u2013100) stress zones impairs HRV, sleep onset, and next-day recovery capacity.",
           "id": 100,
           "links": [],
           "title": "Stress Duration Breakdown",
@@ -209,7 +209,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_trainingstatus_aerobic_low_monthly_load",
+                        "expr": "garmin_trainingstatus_aerobic_low_monthly_load{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Aerobic Low",
                         "queryType": "instant",
@@ -232,7 +232,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_trainingstatus_aerobic_high_monthly_load",
+                        "expr": "garmin_trainingstatus_aerobic_high_monthly_load{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Aerobic High",
                         "queryType": "instant",
@@ -255,7 +255,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_trainingstatus_anaerobic_monthly_load",
+                        "expr": "garmin_trainingstatus_anaerobic_monthly_load{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Anaerobic",
                         "queryType": "instant",
@@ -349,7 +349,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_trainingstatus_status",
+                        "expr": "garmin_trainingstatus_status{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Training Status",
                         "queryType": "instant",
@@ -372,7 +372,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_trainingstatus_acwr_ratio",
+                        "expr": "garmin_trainingstatus_acwr_ratio{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "ACWR Ratio",
                         "queryType": "instant",
@@ -395,7 +395,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_trainingstatus_acwr_percent",
+                        "expr": "garmin_trainingstatus_acwr_percent{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "ACWR %",
                         "queryType": "instant",
@@ -411,10 +411,10 @@
               "transformations": []
             }
           },
-          "description": "Current Garmin training status and Acute:Chronic Workload Ratio. Status: Peaking, Productive, Maintaining, Recovery, or Overreaching. Optimal ACWR: 0.8–1.3 balances adaptation with injury risk management.",
+          "description": "Current Garmin training status and Acute:Chronic Workload Ratio. Status: Peaking, Productive, Maintaining, Recovery, or Overreaching. Optimal ACWR: 0.8\u20131.3 balances adaptation with injury risk management.",
           "id": 102,
           "links": [],
-          "title": "Training Status \u0026 ACWR",
+          "title": "Training Status & ACWR",
           "vizConfig": {
             "group": "stat",
             "kind": "VizConfig",
@@ -494,7 +494,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_total_seconds",
+                        "expr": "garmin_sleep_total_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Total Sleep",
                         "queryType": "instant",
@@ -510,7 +510,7 @@
               "transformations": []
             }
           },
-          "description": "Total sleep duration for the last night. Adults need 7–9 hours. Consistently under 6 hours is associated with impaired cognition, immune function, hormonal regulation, and physical recovery.",
+          "description": "Total sleep duration for the last night. Adults need 7\u20139 hours. Consistently under 6 hours is associated with impaired cognition, immune function, hormonal regulation, and physical recovery.",
           "id": 103,
           "links": [],
           "title": "Total Sleep Time",
@@ -585,7 +585,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "up{service_name=\"garmin_exporter\"}",
+                        "expr": "up{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Garmin exporter",
                         "queryType": "instant",
@@ -672,7 +672,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_auth_login_success",
+                        "expr": "garmin_auth_login_success{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Successful Logins",
                         "queryType": "instant",
@@ -777,7 +777,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_hydration_intake_ml_mL / ((garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL) * 100",
+                        "expr": "garmin_hydration_intake_ml_mL{garmin_account=\"$garmin_account\"} / ((garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"} + garmin_hydration_sweat_loss_ml_mL{garmin_account=\"$garmin_account\"}) or garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"}) * 100",
                         "instant": true,
                         "legendFormat": "Hydration %",
                         "queryType": "instant",
@@ -793,7 +793,7 @@
               "transformations": []
             }
           },
-          "description": "Hydration progress toward your daily goal. General guideline: ~35 mL per kg of body weight per day, increasing with activity level and ambient heat. Even 1–2% dehydration measurably impairs physical and cognitive performance.",
+          "description": "Hydration progress toward your daily goal. General guideline: ~35 mL per kg of body weight per day, increasing with activity level and ambient heat. Even 1\u20132% dehydration measurably impairs physical and cognitive performance.",
           "id": 106,
           "links": [],
           "title": "Hydration Goal Progress",
@@ -881,7 +881,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_hydration_intake_ml_mL",
+                        "expr": "garmin_hydration_intake_ml_mL{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Intake",
                         "queryType": "instant",
@@ -904,7 +904,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_hydration_goal_ml_mL",
+                        "expr": "garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Goal",
                         "queryType": "instant",
@@ -927,7 +927,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "(garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL",
+                        "expr": "(garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"} + garmin_hydration_sweat_loss_ml_mL{garmin_account=\"$garmin_account\"}) or garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Goal + Sweat Loss",
                         "queryType": "instant",
@@ -950,7 +950,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "(garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL",
+                        "expr": "(garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"} + garmin_hydration_sweat_loss_ml_mL{garmin_account=\"$garmin_account\"}) or garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Goal + Sweat Loss",
                         "queryType": "instant",
@@ -1061,7 +1061,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_heartrate_resting_bpm_per_min",
+                        "expr": "garmin_heartrate_resting_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Resting BPM",
                         "queryType": "range",
@@ -1084,7 +1084,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_heartrate_max_bpm_per_min",
+                        "expr": "garmin_heartrate_max_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Max BPM",
                         "queryType": "range",
@@ -1107,7 +1107,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_heartrate_min_bpm_per_min",
+                        "expr": "garmin_heartrate_min_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Min BPM",
                         "queryType": "range",
@@ -1130,7 +1130,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_heartrate_seven_day_avg_resting_bpm_per_min",
+                        "expr": "garmin_heartrate_seven_day_avg_resting_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "7-day Avg Resting",
                         "queryType": "range",
@@ -1146,7 +1146,7 @@
               "transformations": []
             }
           },
-          "description": "Continuous heart rate throughout the day. Normal resting range: 60–100 bpm. Athletes may see 40–60 bpm. Peaks indicate exercise or stress; dips during sleep reflect recovery quality.",
+          "description": "Continuous heart rate throughout the day. Normal resting range: 60\u2013100 bpm. Athletes may see 40\u201360 bpm. Peaks indicate exercise or stress; dips during sleep reflect recovery quality.",
           "id": 22,
           "links": [],
           "title": "Heart Rate Trends",
@@ -1252,7 +1252,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_hrv_last_night_ms_milliseconds",
+                        "expr": "garmin_sleep_hrv_last_night_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Last Night HRV",
                         "queryType": "range",
@@ -1275,7 +1275,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_hrv_weekly_avg_ms_milliseconds",
+                        "expr": "garmin_sleep_hrv_weekly_avg_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "7-day Avg HRV",
                         "queryType": "range",
@@ -1298,7 +1298,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_readiness_hrv_weekly_avg_ms_milliseconds",
+                        "expr": "garmin_training_readiness_hrv_weekly_avg_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Training HRV Baseline",
                         "queryType": "range",
@@ -1314,7 +1314,7 @@
               "transformations": []
             }
           },
-          "description": "Millisecond variation between consecutive heartbeats. Higher HRV generally indicates better recovery and fitness. Typical range: 20–70 ms, though this varies widely by age and fitness level. Track trends rather than absolute values.",
+          "description": "Millisecond variation between consecutive heartbeats. Higher HRV generally indicates better recovery and fitness. Typical range: 20\u201370 ms, though this varies widely by age and fitness level. Track trends rather than absolute values.",
           "id": 23,
           "links": [],
           "title": "HRV (Heart Rate Variability)",
@@ -1423,7 +1423,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_deep_seconds",
+                        "expr": "garmin_sleep_deep_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Deep Sleep",
                         "queryType": "instant",
@@ -1446,7 +1446,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_rem_seconds",
+                        "expr": "garmin_sleep_rem_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "REM Sleep",
                         "queryType": "instant",
@@ -1469,7 +1469,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_light_seconds",
+                        "expr": "garmin_sleep_light_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Light Sleep",
                         "queryType": "instant",
@@ -1492,7 +1492,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_awake_seconds",
+                        "expr": "garmin_sleep_awake_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Awake",
                         "queryType": "instant",
@@ -1508,7 +1508,7 @@
               "transformations": []
             }
           },
-          "description": "Breakdown of sleep into Light, Deep, REM, and Awake periods. Adults need 7–9 hours total. Aim for 15–20% deep sleep and 20–25% REM for optimal recovery and cognitive function.",
+          "description": "Breakdown of sleep into Light, Deep, REM, and Awake periods. Adults need 7\u20139 hours total. Aim for 15\u201320% deep sleep and 20\u201325% REM for optimal recovery and cognitive function.",
           "id": 24,
           "links": [],
           "title": "Sleep Stages",
@@ -1647,7 +1647,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_stress_avg_level",
+                        "expr": "garmin_stress_avg_level{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Avg Stress",
                         "queryType": "range",
@@ -1670,7 +1670,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_stress_max_level",
+                        "expr": "garmin_stress_max_level{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Max Stress",
                         "queryType": "range",
@@ -1693,7 +1693,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_avg_stress",
+                        "expr": "garmin_sleep_avg_stress{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Sleep Stress",
                         "queryType": "range",
@@ -1709,7 +1709,7 @@
               "transformations": []
             }
           },
-          "description": "Garmin-calculated stress score based on HRV fluctuations. Scale: 0–25 (resting), 26–50 (low), 51–75 (medium), 76–100 (high). Chronic high stress impacts HRV, sleep quality, and recovery.",
+          "description": "Garmin-calculated stress score based on HRV fluctuations. Scale: 0\u201325 (resting), 26\u201350 (low), 51\u201375 (medium), 76\u2013100 (high). Chronic high stress impacts HRV, sleep quality, and recovery.",
           "id": 25,
           "links": [],
           "title": "Stress Levels",
@@ -1788,7 +1788,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_wellness_active_seconds",
+                        "expr": "garmin_wellness_active_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Active",
                         "queryType": "range",
@@ -1812,7 +1812,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_wellness_highly_active_seconds",
+                        "expr": "garmin_wellness_highly_active_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Highly Active",
                         "queryType": "range",
@@ -1836,7 +1836,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_wellness_sedentary_seconds",
+                        "expr": "garmin_wellness_sedentary_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Sedentary",
                         "queryType": "range",
@@ -1859,7 +1859,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "garmin_wellness_active_seconds +\ngarmin_wellness_highly_active_seconds +\ngarmin_wellness_sedentary_seconds",
+                        "expr": "garmin_wellness_active_seconds{garmin_account=\"$garmin_account\"} +\ngarmin_wellness_highly_active_seconds{garmin_account=\"$garmin_account\"} +\ngarmin_wellness_sedentary_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Total",
                         "range": true
@@ -1874,7 +1874,7 @@
               "transformations": []
             }
           },
-          "description": "Daily breakdown of active, sedentary, and lightly active minutes. WHO guidelines recommend 150–300 min of moderate activity per week. Prolonged sedentary periods (\u003e30 min) increase cardiovascular risk.",
+          "description": "Daily breakdown of active, sedentary, and lightly active minutes. WHO guidelines recommend 150\u2013300 min of moderate activity per week. Prolonged sedentary periods (>30 min) increase cardiovascular risk.",
           "id": 26,
           "links": [],
           "title": "Activity Time (Active vs Sedentary)",
@@ -1952,7 +1952,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_active_kilocalories_kcal",
+                        "expr": "garmin_wellness_active_kilocalories_kcal{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Active",
                         "queryType": "range",
@@ -1975,7 +1975,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_bmr_kilocalories_kcal",
+                        "expr": "garmin_wellness_bmr_kilocalories_kcal{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "BMR (Base Metabolic)",
                         "queryType": "range",
@@ -1998,7 +1998,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_total_kilocalories_kcal",
+                        "expr": "garmin_wellness_total_kilocalories_kcal{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Total",
                         "queryType": "range",
@@ -2093,7 +2093,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_activity_duration_seconds_total",
+                        "expr": "garmin_activity_duration_seconds_total{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "{{type}}",
                         "queryType": "range",
@@ -2116,7 +2116,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(garmin_activity_duration_seconds_total)",
+                        "expr": "sum(garmin_activity_duration_seconds_total{garmin_account=\"$garmin_account\"})",
                         "instant": false,
                         "legendFormat": "Total",
                         "range": true
@@ -2209,7 +2209,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_intensity_vigorous_minutes_total",
+                        "expr": "garmin_intensity_vigorous_minutes_total{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Vigorous",
                         "queryType": "instant",
@@ -2232,7 +2232,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_intensity_moderate_minutes_total",
+                        "expr": "garmin_intensity_moderate_minutes_total{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Moderate",
                         "queryType": "instant",
@@ -2255,7 +2255,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_intensity_weekly_goal_minutes",
+                        "expr": "garmin_intensity_weekly_goal_minutes{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Weekly Goal",
                         "queryType": "instant",
@@ -2271,7 +2271,7 @@
               "transformations": []
             }
           },
-          "description": "Cumulative vigorous and moderate intensity exercise minutes per week. WHO recommends ≥150 min moderate or ≥75 min vigorous activity weekly. Vigorous minutes count double toward the target.",
+          "description": "Cumulative vigorous and moderate intensity exercise minutes per week. WHO recommends \u2265150 min moderate or \u226575 min vigorous activity weekly. Vigorous minutes count double toward the target.",
           "id": 29,
           "links": [],
           "title": "Weekly Intensity Minutes",
@@ -2349,7 +2349,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_total_steps",
+                        "expr": "garmin_wellness_total_steps{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Steps",
                         "queryType": "instant",
@@ -2440,7 +2440,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_heartrate_resting_bpm_per_min",
+                        "expr": "garmin_heartrate_resting_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Resting BPM",
                         "queryType": "instant",
@@ -2456,7 +2456,7 @@
               "transformations": []
             }
           },
-          "description": "Average heart rate during rest, typically measured during sleep. Normal adult range: 60–100 bpm. Lower values (40–60 bpm) suggest good cardiovascular fitness. A rising trend may signal illness or overtraining.",
+          "description": "Average heart rate during rest, typically measured during sleep. Normal adult range: 60\u2013100 bpm. Lower values (40\u201360 bpm) suggest good cardiovascular fitness. A rising trend may signal illness or overtraining.",
           "id": 32,
           "links": [],
           "title": "Resting Heart Rate",
@@ -2531,7 +2531,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_readiness_score",
+                        "expr": "garmin_training_readiness_score{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Score",
                         "queryType": "instant",
@@ -2547,7 +2547,7 @@
               "transformations": []
             }
           },
-          "description": "Garmin composite score (0–100) estimating how prepared your body is for training. Factors include sleep score, recovery time, HRV status, and training load. A score ≥70 suggests readiness for high-intensity effort.",
+          "description": "Garmin composite score (0\u2013100) estimating how prepared your body is for training. Factors include sleep score, recovery time, HRV status, and training load. A score \u226570 suggests readiness for high-intensity effort.",
           "id": 33,
           "links": [],
           "title": "Training Readiness",
@@ -2624,9 +2624,9 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_spo2_avg_percent",
+                        "expr": "garmin_spo2_avg_percent{garmin_account=\"$garmin_account\"}",
                         "instant": true,
-                        "legendFormat": "Avg SpO₂",
+                        "legendFormat": "Avg SpO\u2082",
                         "queryType": "instant",
                         "range": false
                       },
@@ -2647,9 +2647,9 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_spo2_lowest_percent",
+                        "expr": "garmin_spo2_lowest_percent{garmin_account=\"$garmin_account\"}",
                         "instant": true,
-                        "legendFormat": "Lowest SpO₂",
+                        "legendFormat": "Lowest SpO\u2082",
                         "queryType": "instant",
                         "range": false
                       },
@@ -2670,9 +2670,9 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_spo2_seven_day_avg_percent",
+                        "expr": "garmin_spo2_seven_day_avg_percent{garmin_account=\"$garmin_account\"}",
                         "instant": true,
-                        "legendFormat": "7-Day Avg SpO₂",
+                        "legendFormat": "7-Day Avg SpO\u2082",
                         "queryType": "instant",
                         "range": false
                       },
@@ -2686,10 +2686,10 @@
               "transformations": []
             }
           },
-          "description": "Estimated blood oxygen saturation via optical sensor. Normal range: 95–100%. Values of 90–94% may warrant attention; below 90% is clinically concerning. Useful for altitude acclimatization or screening sleep-disordered breathing.",
+          "description": "Estimated blood oxygen saturation via optical sensor. Normal range: 95\u2013100%. Values of 90\u201394% may warrant attention; below 90% is clinically concerning. Useful for altitude acclimatization or screening sleep-disordered breathing.",
           "id": 34,
           "links": [],
-          "title": "Blood Oxygen (SpO₂)",
+          "title": "Blood Oxygen (SpO\u2082)",
           "vizConfig": {
             "group": "stat",
             "kind": "VizConfig",
@@ -2763,7 +2763,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_stress_avg_level",
+                        "expr": "garmin_stress_avg_level{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Stress",
                         "queryType": "instant",
@@ -2779,7 +2779,7 @@
               "transformations": []
             }
           },
-          "description": "Average stress score for the day on a 0–100 scale, derived from HRV-based autonomic nervous system analysis. Scores consistently above 75 indicate elevated sympathetic activity and reduced recovery capacity.",
+          "description": "Average stress score for the day on a 0\u2013100 scale, derived from HRV-based autonomic nervous system analysis. Scores consistently above 75 indicate elevated sympathetic activity and reduced recovery capacity.",
           "id": 35,
           "links": [],
           "title": "Avg Stress Level",
@@ -2860,7 +2860,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_total_steps / garmin_wellness_step_goal * 100",
+                        "expr": "garmin_wellness_total_steps{garmin_account=\"$garmin_account\"} / garmin_wellness_step_goal{garmin_account=\"$garmin_account\"} * 100",
                         "instant": true,
                         "legendFormat": "Goal %",
                         "queryType": "instant",
@@ -2953,7 +2953,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_body_battery_latest",
+                        "expr": "garmin_wellness_body_battery_latest{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Latest",
                         "queryType": "range",
@@ -2976,7 +2976,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_body_battery_highest",
+                        "expr": "garmin_wellness_body_battery_highest{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Highest",
                         "queryType": "range",
@@ -2999,7 +2999,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_body_battery_lowest",
+                        "expr": "garmin_wellness_body_battery_lowest{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Lowest",
                         "queryType": "range",
@@ -3169,7 +3169,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_body_battery_charged",
+                        "expr": "garmin_wellness_body_battery_charged{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Charged",
                         "queryType": "range",
@@ -3192,7 +3192,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_body_battery_drained",
+                        "expr": "garmin_wellness_body_battery_drained{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Drained",
                         "queryType": "range",
@@ -3211,7 +3211,7 @@
           "description": "Energy gained (sleep and rest) versus energy consumed (activity and stress) over time. Net negative drain across multiple days indicates accumulated fatigue and a need for recovery or easy days.",
           "id": 54,
           "links": [],
-          "title": "Body Battery Charge \u0026 Drain",
+          "title": "Body Battery Charge & Drain",
           "vizConfig": {
             "group": "gauge",
             "kind": "VizConfig",
@@ -3321,9 +3321,9 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_vo2max_generic_mL_per_min_kg",
+                        "expr": "garmin_training_vo2max_generic_mL_per_min_kg{garmin_account=\"$garmin_account\"}",
                         "instant": true,
-                        "legendFormat": "VO₂ Max",
+                        "legendFormat": "VO\u2082 Max",
                         "queryType": "instant",
                         "range": false
                       },
@@ -3337,10 +3337,10 @@
               "transformations": []
             }
           },
-          "description": "Estimated maximum oxygen consumption in mL/kg/min — a key aerobic fitness indicator. Average adults: 35–45 (women), 40–50 (men). Elite endurance athletes: 55–85. Improves with consistent aerobic training.",
+          "description": "Estimated maximum oxygen consumption in mL/kg/min \u2014 a key aerobic fitness indicator. Average adults: 35\u201345 (women), 40\u201350 (men). Elite endurance athletes: 55\u201385. Improves with consistent aerobic training.",
           "id": 55,
           "links": [],
-          "title": "VO₂ Max",
+          "title": "VO\u2082 Max",
           "vizConfig": {
             "group": "stat",
             "kind": "VizConfig",
@@ -3412,7 +3412,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_readiness_recovery_minutes",
+                        "expr": "garmin_training_readiness_recovery_minutes{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Recovery",
                         "queryType": "instant",
@@ -3503,7 +3503,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_readiness_sleep_score",
+                        "expr": "garmin_training_readiness_sleep_score{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Sleep Score",
                         "queryType": "instant",
@@ -3519,7 +3519,7 @@
               "transformations": []
             }
           },
-          "description": "Garmin sleep score (0–100) reflecting sleep duration, stages, and quality. Scores ≥75 indicate restorative sleep. Poor sleep scores are a leading indicator of next-day performance, mood, and stress levels.",
+          "description": "Garmin sleep score (0\u2013100) reflecting sleep duration, stages, and quality. Scores \u226575 indicate restorative sleep. Poor sleep scores are a leading indicator of next-day performance, mood, and stress levels.",
           "id": 57,
           "links": [],
           "title": "Readiness Sleep Score",
@@ -3596,7 +3596,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_race_prediction_5k_seconds",
+                        "expr": "garmin_training_race_prediction_5k_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "5K",
                         "queryType": "range",
@@ -3619,7 +3619,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_training_race_prediction_10k_seconds",
+                        "expr": "garmin_training_race_prediction_10k_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "10K",
                         "queryType": "range",
@@ -3643,7 +3643,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_training_race_prediction_half_marathon_seconds",
+                        "expr": "garmin_training_race_prediction_half_marathon_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Half Marathon",
                         "queryType": "range",
@@ -3666,7 +3666,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "garmin_training_race_prediction_marathon_seconds",
+                        "expr": "garmin_training_race_prediction_marathon_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Marathon",
                         "range": true
@@ -3681,7 +3681,7 @@
               "transformations": []
             }
           },
-          "description": "Estimated finish times for 5K, 10K, half marathon, and marathon distances based on current VO₂ Max and training history. Predictions improve in accuracy with more running data over time.",
+          "description": "Estimated finish times for 5K, 10K, half marathon, and marathon distances based on current VO\u2082 Max and training history. Predictions improve in accuracy with more running data over time.",
           "id": 58,
           "links": [],
           "title": "Race Predictions",
@@ -3752,7 +3752,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_respiration_avg_waking_bpm_per_min",
+                        "expr": "garmin_respiration_avg_waking_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Avg Waking",
                         "queryType": "range",
@@ -3775,7 +3775,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_respiration_highest_bpm_per_min",
+                        "expr": "garmin_respiration_highest_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Highest",
                         "queryType": "range",
@@ -3798,7 +3798,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_respiration_lowest_bpm_per_min",
+                        "expr": "garmin_respiration_lowest_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Lowest",
                         "queryType": "range",
@@ -3814,7 +3814,7 @@
               "transformations": []
             }
           },
-          "description": "Average breathing rate during waking hours in breaths per minute. Normal adult range: 12–20 breaths/min. Elevated rates can indicate respiratory illness, high stress, or altitude effects.",
+          "description": "Average breathing rate during waking hours in breaths per minute. Normal adult range: 12\u201320 breaths/min. Elevated rates can indicate respiratory illness, high stress, or altitude effects.",
           "id": 59,
           "links": [],
           "title": "Waking Respiration Rate",
@@ -3885,7 +3885,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_avg_respiration_bpm_per_min",
+                        "expr": "garmin_sleep_avg_respiration_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Avg Sleep",
                         "queryType": "range",
@@ -3908,7 +3908,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_highest_respiration_bpm_per_min",
+                        "expr": "garmin_sleep_highest_respiration_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Highest Sleep",
                         "queryType": "range",
@@ -3931,7 +3931,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_lowest_respiration_bpm_per_min",
+                        "expr": "garmin_sleep_lowest_respiration_bpm_per_min{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "Lowest Sleep",
                         "queryType": "range",
@@ -3947,7 +3947,7 @@
               "transformations": []
             }
           },
-          "description": "Average breaths per minute during sleep. Normal range: 12–20 breaths/min. Significant fluctuations or values consistently outside this range may indicate sleep-disordered breathing.",
+          "description": "Average breaths per minute during sleep. Normal range: 12\u201320 breaths/min. Significant fluctuations or values consistently outside this range may indicate sleep-disordered breathing.",
           "id": 60,
           "links": [],
           "title": "Sleep Respiration Rate",
@@ -4018,7 +4018,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_nap_seconds",
+                        "expr": "garmin_sleep_nap_seconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Nap",
                         "queryType": "instant",
@@ -4034,7 +4034,7 @@
               "transformations": []
             }
           },
-          "description": "Duration of detected naps (short sleep periods outside the main sleep window). Short naps (10–30 min) can improve alertness and performance. Frequent long naps may indicate insufficient nighttime sleep.",
+          "description": "Duration of detected naps (short sleep periods outside the main sleep window). Short naps (10\u201330 min) can improve alertness and performance. Frequent long naps may indicate insufficient nighttime sleep.",
           "id": 61,
           "links": [],
           "title": "Nap Time",
@@ -4101,7 +4101,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_restless_moments_total",
+                        "expr": "garmin_sleep_restless_moments_total{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Restless",
                         "queryType": "instant",
@@ -4192,9 +4192,9 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_spo2_avg_percent",
+                        "expr": "garmin_sleep_spo2_avg_percent{garmin_account=\"$garmin_account\"}",
                         "instant": true,
-                        "legendFormat": "Sleep SpO₂",
+                        "legendFormat": "Sleep SpO\u2082",
                         "queryType": "instant",
                         "range": false
                       },
@@ -4208,10 +4208,10 @@
               "transformations": []
             }
           },
-          "description": "Blood oxygen saturation measured via optical sensor during sleep. Normal: 95–100%. Repeated dips below 90% during sleep may indicate sleep apnea and warrant medical evaluation.",
+          "description": "Blood oxygen saturation measured via optical sensor during sleep. Normal: 95\u2013100%. Repeated dips below 90% during sleep may indicate sleep apnea and warrant medical evaluation.",
           "id": 63,
           "links": [],
-          "title": "Sleep SpO₂",
+          "title": "Sleep SpO\u2082",
           "vizConfig": {
             "group": "stat",
             "kind": "VizConfig",
@@ -4285,7 +4285,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_hrv_baseline_balanced_low_ms_milliseconds",
+                        "expr": "garmin_sleep_hrv_baseline_balanced_low_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Balanced Low",
                         "queryType": "instant",
@@ -4308,7 +4308,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_hrv_baseline_balanced_upper_ms_milliseconds",
+                        "expr": "garmin_sleep_hrv_baseline_balanced_upper_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Balanced Upper",
                         "queryType": "instant",
@@ -4331,7 +4331,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_hrv_baseline_low_upper_ms_milliseconds",
+                        "expr": "garmin_sleep_hrv_baseline_low_upper_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Low Upper",
                         "queryType": "instant",
@@ -4354,7 +4354,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_sleep_hrv_last_night_5min_high_ms_milliseconds",
+                        "expr": "garmin_sleep_hrv_last_night_5min_high_ms_milliseconds{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Last Night 5min High",
                         "queryType": "instant",
@@ -4441,7 +4441,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_body_battery_latest",
+                        "expr": "garmin_wellness_body_battery_latest{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Current",
                         "queryType": "instant",
@@ -4457,7 +4457,7 @@
               "transformations": []
             }
           },
-          "description": "Current Body Battery energy reserve on a 0–100 scale. \u003e75: high readiness; 50–75: good; 25–50: moderate fatigue; \u003c25: rest is needed before any intense activity. Recharges primarily during sleep.",
+          "description": "Current Body Battery energy reserve on a 0\u2013100 scale. >75: high readiness; 50\u201375: good; 25\u201350: moderate fatigue; <25: rest is needed before any intense activity. Recharges primarily during sleep.",
           "id": 67,
           "links": [],
           "title": "Body Battery",
@@ -4548,7 +4548,7 @@
                   "showLineNumbers": false,
                   "showMiniMap": false
                 },
-                "content": "\u003cdiv style=\"display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;padding:12px;text-align:center\"\u003e\n  \u003cimg\n    src=\"https://a-static.mlcdn.com.br/420x420/smartwatch-gps-garmin-forerunner-265-amoled-music-preto/lojaglobaltechautorizadagarmin/010-02810-10/c7b844b856e446517b048afe38a5bc44.jpeg\"\n    alt=\"Garmin Forerunner 265\"\n    style=\"max-height:200px;max-width:100%;object-fit:contain;filter:drop-shadow(0 6px 16px rgba(0,0,0,0.6))\"\n  /\u003e\n\u003c/div\u003e",
+                "content": "<div style=\"display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;padding:12px;text-align:center\">\n  <img\n    src=\"https://a-static.mlcdn.com.br/420x420/smartwatch-gps-garmin-forerunner-265-amoled-music-preto/lojaglobaltechautorizadagarmin/010-02810-10/c7b844b856e446517b048afe38a5bc44.jpeg\"\n    alt=\"Garmin Forerunner 265\"\n    style=\"max-height:200px;max-width:100%;object-fit:contain;filter:drop-shadow(0 6px 16px rgba(0,0,0,0.6))\"\n  />\n</div>",
                 "mode": "html"
               }
             },
@@ -4575,7 +4575,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_device_count",
+                        "expr": "garmin_device_count{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Devices",
                         "queryType": "instant",
@@ -4658,7 +4658,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_device_info",
+                        "expr": "garmin_device_info{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "{{type}}",
                         "queryType": "instant",
@@ -4674,7 +4674,7 @@
               "transformations": []
             }
           },
-          "description": "Model name of your paired Garmin device. Confirms which device is reporting data and helps identify sensor capabilities (e.g., SpO₂, ECG, body temperature) available on that model.",
+          "description": "Model name of your paired Garmin device. Confirms which device is reporting data and helps identify sensor capabilities (e.g., SpO\u2082, ECG, body temperature) available on that model.",
           "id": 71,
           "links": [],
           "title": "Device Type",
@@ -4741,7 +4741,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_floors_ascended",
+                        "expr": "garmin_wellness_floors_ascended{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Floors Ascended",
                         "queryType": "instant",
@@ -4764,7 +4764,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_floors_descended",
+                        "expr": "garmin_wellness_floors_descended{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Floors Descended",
                         "queryType": "instant",
@@ -4787,7 +4787,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_wellness_floors_ascended_goal",
+                        "expr": "garmin_wellness_floors_ascended_goal{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Ascended Goal",
                         "queryType": "instant",
@@ -4882,7 +4882,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "garmin_activity_distance_meters_total",
+                        "expr": "garmin_activity_distance_meters_total{garmin_account=\"$garmin_account\"}",
                         "instant": false,
                         "legendFormat": "{{type}}",
                         "queryType": "range",
@@ -4905,7 +4905,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(garmin_activity_distance_meters_total)",
+                        "expr": "sum(garmin_activity_distance_meters_total{garmin_account=\"$garmin_account\"})",
                         "instant": false,
                         "legendFormat": "Total",
                         "range": true
@@ -5002,7 +5002,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_activity_count",
+                        "expr": "garmin_activity_count{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "{{type}}",
                         "queryType": "instant",
@@ -5025,7 +5025,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_activity_lifetime_count",
+                        "expr": "garmin_activity_lifetime_count{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "Lifetime Total",
                         "queryType": "instant",
@@ -5119,7 +5119,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "garmin_activity_calories_total_kcal",
+                        "expr": "garmin_activity_calories_total_kcal{garmin_account=\"$garmin_account\"}",
                         "instant": true,
                         "legendFormat": "{{type}}",
                         "queryType": "instant",
@@ -5332,7 +5332,7 @@
                   ]
                 }
               },
-              "title": "❤️ Heart Rate \u0026 HRV"
+              "title": "\u2764\ufe0f Heart Rate & HRV"
             }
           },
           {
@@ -5387,7 +5387,7 @@
                   ]
                 }
               },
-              "title": "😴 Sleep"
+              "title": "\ud83d\ude34 Sleep"
             }
           },
           {
@@ -5507,7 +5507,7 @@
                   ]
                 }
               },
-              "title": "🏃 Activity \u0026 Wellness"
+              "title": "\ud83c\udfc3 Activity & Wellness"
             }
           },
           {
@@ -5562,7 +5562,7 @@
                   ]
                 }
               },
-              "title": "🔋 Body Battery"
+              "title": "\ud83d\udd0b Body Battery"
             }
           },
           {
@@ -5656,7 +5656,7 @@
                   ]
                 }
               },
-              "title": "🏋️ Training \u0026 Performance"
+              "title": "\ud83c\udfcb\ufe0f Training & Performance"
             }
           },
           {
@@ -5698,7 +5698,7 @@
                   ]
                 }
               },
-              "title": "🫁 Respiration"
+              "title": "\ud83e\udec1 Respiration"
             }
           },
           {
@@ -5779,7 +5779,7 @@
                   ]
                 }
               },
-              "title": "😴 Extra Sleep Detail"
+              "title": "\ud83d\ude34 Extra Sleep Detail"
             }
           },
           {
@@ -5860,7 +5860,7 @@
                   ]
                 }
               },
-              "title": "ℹ️ Device Info"
+              "title": "\u2139\ufe0f Device Info"
             }
           },
           {
@@ -5902,7 +5902,7 @@
                   ]
                 }
               },
-              "title": "💧 Hydration"
+              "title": "\ud83d\udca7 Hydration"
             }
           }
         ]
@@ -5953,7 +5953,7 @@
       "timezone": "browser",
       "to": "now"
     },
-    "title": "Garmin Health \u0026 Fitness",
+    "title": "Garmin Health & Fitness",
     "variables": [
       {
         "kind": "DatasourceVariable",
@@ -5973,6 +5973,42 @@
           "refresh": "onDashboardLoad",
           "regex": "/(^Prometheus$|-prom$)/",
           "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "garmin_account",
+          "current": {
+            "text": "arthur",
+            "value": "arthur"
+          },
+          "label": "Garmin Account",
+          "hide": "dontHide",
+          "refresh": "onDashboardLoad",
+          "skipUrlSync": false,
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "spec": {
+              "label": "garmin_account",
+              "metric": "garmin_auth_login_success",
+              "qryType": 1,
+              "query": "label_values(garmin_auth_login_success,garmin_account)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "labels": {
+              "grafana.app/export-label": "prometheus-1"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "alphabeticalAsc",
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "allowCustomValue": false
         }
       }
     ]

--- a/opentelemetry-collector/config.yaml
+++ b/opentelemetry-collector/config.yaml
@@ -24,9 +24,16 @@ receivers:
         - job_name: 'node_exporter'
           static_configs:
             - targets: ['node_exporter:9100']
-        - job_name: 'garmin_exporter'
+        - job_name: 'garmin_exporter_arthur'
           static_configs:
-            - targets: ['garmin_exporter:10045']
+            - targets: ['garmin_exporter_arthur:10045']
+              labels:
+                garmin_account: arthur
+        - job_name: 'garmin_exporter_julia'
+          static_configs:
+            - targets: ['garmin_exporter_julia:10045']
+              labels:
+                garmin_account: julia
         - job_name: 'blackbox_exporter'
           metrics_path: /probe
           params:

--- a/prometheus/rules/garmin-rules.yml
+++ b/prometheus/rules/garmin-rules.yml
@@ -3,12 +3,19 @@ groups:
   rules:
 
   - record: garmin:hydration_target_ml
-    expr: (garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL
+    expr: |
+      (
+        max by (garmin_account) (garmin_hydration_goal_ml_mL)
+        +
+        max by (garmin_account) (garmin_hydration_sweat_loss_ml_mL)
+      )
+      or
+      max by (garmin_account) (garmin_hydration_goal_ml_mL)
 
   - record: garmin:hydration_progress:ratio
     expr: |
       clamp_max(
-        garmin_hydration_intake_ml_mL
+        max by (garmin_account) (garmin_hydration_intake_ml_mL)
           / garmin:hydration_target_ml
           and garmin:hydration_target_ml > 0,
         1
@@ -18,11 +25,13 @@ groups:
   - alert: HydrationBehindPace
     expr: |
       (
-        predict_linear(
-          garmin_hydration_intake_ml_mL[6h],
-          scalar(
-            (19 - hour(vector(time() - 3 * 3600))) * 3600
-            - minute(vector(time() - 3 * 3600)) * 60
+        max by (garmin_account) (
+          predict_linear(
+            garmin_hydration_intake_ml_mL[6h],
+            scalar(
+              (19 - hour(vector(time() - 3 * 3600))) * 3600
+              - minute(vector(time() - 3 * 3600)) * 60
+            )
           )
         )
           < garmin:hydration_target_ml

--- a/prometheus/tests/garmin-rules.test.yml
+++ b/prometheus/tests/garmin-rules.test.yml
@@ -4,23 +4,45 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  - name: hydration rules use OTLP unit-suffixed metrics
+  - name: hydration rules keep Garmin accounts separate
     interval: 1m
     input_series:
-      - series: garmin_hydration_intake_ml_mL
-        values: 500x10
-      - series: garmin_hydration_goal_ml_mL
-        values: 2500x10
-      - series: garmin_hydration_sweat_loss_ml_mL
-        values: 300x10
+      - series: garmin_hydration_intake_ml_mL{garmin_account="arthur"}
+        values: 500x800
+      - series: garmin_hydration_goal_ml_mL{garmin_account="arthur"}
+        values: 2500x800
+      - series: garmin_hydration_sweat_loss_ml_mL{garmin_account="arthur"}
+        values: 300x800
+      - series: garmin_hydration_intake_ml_mL{garmin_account="julia"}
+        values: 3000x800
+      - series: garmin_hydration_goal_ml_mL{garmin_account="julia"}
+        values: 2000x800
+      - series: garmin_hydration_sweat_loss_ml_mL{garmin_account="julia"}
+        values: 100x800
     promql_expr_test:
       - expr: garmin:hydration_target_ml
         eval_time: 5m
         exp_samples:
-          - labels: garmin:hydration_target_ml
+          - labels: garmin:hydration_target_ml{garmin_account="arthur"}
             value: 2800
+          - labels: garmin:hydration_target_ml{garmin_account="julia"}
+            value: 2100
       - expr: garmin:hydration_progress:ratio
         eval_time: 5m
         exp_samples:
-          - labels: garmin:hydration_progress:ratio
+          - labels: garmin:hydration_progress:ratio{garmin_account="arthur"}
             value: 0.17857142857142858
+          - labels: garmin:hydration_progress:ratio{garmin_account="julia"}
+            value: 1
+    alert_rule_test:
+      - eval_time: 12h
+        alertname: HydrationBehindPace
+        exp_alerts:
+          - exp_labels:
+              alertname: HydrationBehindPace
+              garmin_account: arthur
+              severity: critical
+              service: hydration
+              team: garmin-health
+            exp_annotations:
+              description: "Hydration intake is not on track to reach today's Garmin goal plus sweat loss."

--- a/scripts/verify-local-stack.sh
+++ b/scripts/verify-local-stack.sh
@@ -19,7 +19,8 @@ PYROSCOPE_URL=${PYROSCOPE_URL:-http://localhost:4040}
 EXPECTED_PROMETHEUS_JOBS=(
   home-monitoring/alertmanager
   home-monitoring/blackbox_exporter
-  home-monitoring/garmin_exporter
+  home-monitoring/garmin_exporter_arthur
+  home-monitoring/garmin_exporter_julia
   home-monitoring/grafana
   home-monitoring/loki
   home-monitoring/node_exporter
@@ -32,7 +33,8 @@ EXPECTED_PROMETHEUS_JOBS=(
 EXPECTED_LOKI_LOG_SERVICES=(
   alertmanager
   blackbox_exporter
-  garmin_exporter
+  garmin_exporter_arthur
+  garmin_exporter_julia
   grafana
   loki
   node_exporter
@@ -44,7 +46,8 @@ EXPECTED_LOKI_LOG_SERVICES=(
 
 CI_QUIET_LOKI_LOG_SERVICES=(
   blackbox_exporter
-  garmin_exporter
+  garmin_exporter_arthur
+  garmin_exporter_julia
   node_exporter
   prometheus
 )
@@ -75,7 +78,8 @@ EXPECTED_PROFILE_SERVICES=(
 
 # Services that may exit or restart when credentials are invalid (e.g. CI placeholders).
 COMPOSE_RUNNING_OPTIONAL_SERVICES=(
-  garmin_exporter
+  garmin_exporter_arthur
+  garmin_exporter_julia
 )
 
 usage() {
@@ -397,7 +401,7 @@ PY
 
 loki_has_app_o11y_service_logs() {
   local query response
-  query='sum by (service_name, service_namespace, deployment_environment) (count_over_time({service_namespace="home-monitoring", deployment_environment="homelab", service_name=~"prometheus|grafana|otel-collector|loki|tempo|pyroscope|alertmanager|node_exporter|blackbox_exporter|garmin_exporter"}[5m]))'
+  query='sum by (service_name, service_namespace, deployment_environment) (count_over_time({service_namespace="home-monitoring", deployment_environment="homelab", service_name=~"prometheus|grafana|otel-collector|loki|tempo|pyroscope|alertmanager|node_exporter|blackbox_exporter|garmin_exporter_arthur|garmin_exporter_julia"}[5m]))'
   response=$(curl -fsS --get "${LOKI_URL}/loki/api/v1/query" \
     --data-urlencode "query=${query}")
 

--- a/terraform/grafana/alerting.tf
+++ b/terraform/grafana/alerting.tf
@@ -11,110 +11,115 @@ resource "grafana_rule_group" "hydration_pace" {
   folder_uid       = grafana_folder.hydration_alerts.uid
   interval_seconds = 60
 
-  rule {
-    name           = "Hydration behind pace"
-    condition      = "C"
-    no_data_state  = "OK"
-    exec_err_state = "Error"
-    is_paused      = false
+  dynamic "rule" {
+    for_each = local.garmin_accounts
 
-    annotations = {
-      description = "Hydration intake is not on track to reach today's Garmin goal plus sweat loss by 7 PM."
-      summary     = "Hydration is behind pace"
-    }
+    content {
+      name           = "Hydration behind pace (${rule.value})"
+      condition      = "C"
+      no_data_state  = "OK"
+      exec_err_state = "Error"
+      is_paused      = false
 
-    labels = {
-      service  = "hydration"
-      severity = "critical"
-      team     = "garmin-health"
-    }
-
-    data {
-      ref_id         = "A"
-      datasource_uid = var.prometheus_datasource_uid
-
-      relative_time_range {
-        from = 21600
-        to   = 0
+      annotations = {
+        description = "Hydration intake is not on track to reach today's Garmin goal plus sweat loss by 7 PM."
+        summary     = "Hydration is behind pace"
       }
 
-      model = jsonencode({
-        datasource = {
-          type = "prometheus"
-          uid  = var.prometheus_datasource_uid
+      labels = {
+        garmin_account = rule.value
+        service        = "hydration"
+        severity       = "critical"
+        team           = "garmin-health"
+      }
+
+      data {
+        ref_id         = "A"
+        datasource_uid = var.prometheus_datasource_uid
+
+        relative_time_range {
+          from = 21600
+          to   = 0
         }
-        editorMode = "code"
-        # PromQL time functions evaluate timestamps in UTC. Update this offset
-        # whenever the hydration alert should follow a different local timezone.
-        expr          = <<-PROMQL
-          (
-            predict_linear(
-              garmin_hydration_intake_ml_mL[6h],
-              scalar(
-                (19 - hour(vector(time() - 3 * 3600))) * 3600
-                - minute(vector(time() - 3 * 3600)) * 60
+
+        model = jsonencode({
+          datasource = {
+            type = "prometheus"
+            uid  = var.prometheus_datasource_uid
+          }
+          editorMode = "code"
+          # PromQL time functions evaluate timestamps in UTC. Update this offset
+          # whenever the hydration alert should follow a different local timezone.
+          expr          = <<-PROMQL
+            (
+              predict_linear(
+                garmin_hydration_intake_ml_mL{garmin_account="${rule.value}"}[6h],
+                scalar(
+                  (19 - hour(vector(time() - 3 * 3600))) * 3600
+                  - minute(vector(time() - 3 * 3600)) * 60
+                )
               )
+                < bool ((garmin_hydration_goal_ml_mL{garmin_account="${rule.value}"} + garmin_hydration_sweat_loss_ml_mL{garmin_account="${rule.value}"}) or garmin_hydration_goal_ml_mL{garmin_account="${rule.value}"})
             )
-              < bool ((garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL)
-          )
-            and ((garmin_hydration_goal_ml_mL + garmin_hydration_sweat_loss_ml_mL) or garmin_hydration_goal_ml_mL) > 0
-            and on() (hour(vector(time() - 3 * 3600)) >= 7)
-            and on() (hour(vector(time() - 3 * 3600)) < 19)
-        PROMQL
-        hide          = false
-        instant       = true
-        intervalMs    = 1000
-        maxDataPoints = 43200
-        range         = false
-        refId         = "A"
-      })
-    }
-
-    data {
-      ref_id         = "B"
-      datasource_uid = "__expr__"
-
-      relative_time_range {
-        from = 0
-        to   = 0
+              and ((garmin_hydration_goal_ml_mL{garmin_account="${rule.value}"} + garmin_hydration_sweat_loss_ml_mL{garmin_account="${rule.value}"}) or garmin_hydration_goal_ml_mL{garmin_account="${rule.value}"}) > 0
+              and on() (hour(vector(time() - 3 * 3600)) >= 7)
+              and on() (hour(vector(time() - 3 * 3600)) < 19)
+          PROMQL
+          hide          = false
+          instant       = true
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          range         = false
+          refId         = "A"
+        })
       }
 
-      model = jsonencode({
-        datasource = {
-          type = "__expr__"
-          uid  = "__expr__"
+      data {
+        ref_id         = "B"
+        datasource_uid = "__expr__"
+
+        relative_time_range {
+          from = 0
+          to   = 0
         }
-        expression    = "A"
-        hide          = false
-        intervalMs    = 1000
-        maxDataPoints = 43200
-        reducer       = "last"
-        refId         = "B"
-        type          = "reduce"
-      })
-    }
 
-    data {
-      ref_id         = "C"
-      datasource_uid = "__expr__"
-
-      relative_time_range {
-        from = 0
-        to   = 0
+        model = jsonencode({
+          datasource = {
+            type = "__expr__"
+            uid  = "__expr__"
+          }
+          expression    = "A"
+          hide          = false
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          reducer       = "last"
+          refId         = "B"
+          type          = "reduce"
+        })
       }
 
-      model = jsonencode({
-        datasource = {
-          type = "__expr__"
-          uid  = "__expr__"
+      data {
+        ref_id         = "C"
+        datasource_uid = "__expr__"
+
+        relative_time_range {
+          from = 0
+          to   = 0
         }
-        expression    = "$B > 0"
-        hide          = false
-        intervalMs    = 1000
-        maxDataPoints = 43200
-        refId         = "C"
-        type          = "math"
-      })
+
+        model = jsonencode({
+          datasource = {
+            type = "__expr__"
+            uid  = "__expr__"
+          }
+          expression    = "$B > 0"
+          hide          = false
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          refId         = "C"
+          type          = "math"
+        })
+      }
     }
   }
 }
@@ -251,7 +256,7 @@ resource "grafana_notification_policy" "default" {
     }
 
     contact_point = grafana_contact_point.hydration_slo_irm.name
-    group_by      = ["grafana_folder", "alertname"]
+    group_by      = ["grafana_folder", "alertname", "garmin_account"]
   }
 
   policy {

--- a/terraform/grafana/hydration_slo.tf
+++ b/terraform/grafana/hydration_slo.tf
@@ -1,67 +1,83 @@
 locals {
   hydration_slo_utc_offset_seconds = 3 * 3600
   hydration_slo_daily_window       = "18h"
+  garmin_accounts                  = toset(["arthur", "julia"])
 
-  hydration_slo_daily_intake_query = <<-PROMQL
-    max without (instance, service_instance_id) (
-      max_over_time(garmin_hydration_intake_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
-    )
-  PROMQL
-
-  hydration_slo_daily_target_query = <<-PROMQL
-    (
-      (
-        max without (instance, service_instance_id) (
-          max_over_time(garmin_hydration_goal_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
-        )
-        +
-        max without (instance, service_instance_id) (
-          max_over_time(garmin_hydration_sweat_loss_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
-        )
-      )
-      or
+  hydration_slo_daily_intake_query = {
+    for account in local.garmin_accounts : account => <<-PROMQL
       max without (instance, service_instance_id) (
-        max_over_time(garmin_hydration_goal_ml_mL[${local.hydration_slo_daily_window}:$__rate_interval])
-      )
-    )
-  PROMQL
-
-  hydration_slo_daily_ratio_query = <<-PROMQL
-    (
-      sum(
-        ${indent(8, local.hydration_slo_daily_intake_query)}
-        >= bool
-        ${indent(8, local.hydration_slo_daily_target_query)}
-      )
-      /
-      sum(
-        ${indent(8, local.hydration_slo_daily_target_query)} > bool 0
-      )
-    )
-    and on()
-    sum(
-      ${indent(6, local.hydration_slo_daily_target_query)} > bool 0
-    ) > 0
-  PROMQL
-
-  hydration_slo_previous_day_query = join("\n        or\n", [
-    for local_hour in range(24) : <<-PROMQL
-      (
-        last_over_time(
-          (
-            ${indent(8, local.hydration_slo_daily_ratio_query)}
-            and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) >= 23)
-            and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) < 24)
-          )[2h:1m] offset ${local_hour}h
-        )
-        and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) == ${local_hour})
+        max_over_time(garmin_hydration_intake_ml_mL{garmin_account="${account}"}[${local.hydration_slo_daily_window}:$__rate_interval])
       )
     PROMQL
-  ])
+  }
+
+  hydration_slo_daily_target_query = {
+    for account in local.garmin_accounts : account => <<-PROMQL
+      (
+        (
+          max without (instance, service_instance_id) (
+            max_over_time(garmin_hydration_goal_ml_mL{garmin_account="${account}"}[${local.hydration_slo_daily_window}:$__rate_interval])
+          )
+          +
+          max without (instance, service_instance_id) (
+            max_over_time(garmin_hydration_sweat_loss_ml_mL{garmin_account="${account}"}[${local.hydration_slo_daily_window}:$__rate_interval])
+          )
+        )
+        or
+        max without (instance, service_instance_id) (
+          max_over_time(garmin_hydration_goal_ml_mL{garmin_account="${account}"}[${local.hydration_slo_daily_window}:$__rate_interval])
+        )
+      )
+    PROMQL
+  }
+
+  hydration_slo_daily_ratio_query = {
+    for account in local.garmin_accounts : account => <<-PROMQL
+      (
+        sum(
+          ${indent(10, local.hydration_slo_daily_intake_query[account])}
+          >= bool
+          ${indent(10, local.hydration_slo_daily_target_query[account])}
+        )
+        /
+        sum(
+          ${indent(10, local.hydration_slo_daily_target_query[account])} > bool 0
+        )
+      )
+      and on()
+      sum(
+        ${indent(8, local.hydration_slo_daily_target_query[account])} > bool 0
+      ) > 0
+    PROMQL
+  }
+
+  hydration_slo_previous_day_query = {
+    for account in local.garmin_accounts : account => join("\n        or\n", [
+      for local_hour in range(24) : <<-PROMQL
+        (
+          last_over_time(
+            (
+              ${indent(10, local.hydration_slo_daily_ratio_query[account])}
+              and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) >= 23)
+              and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) < 24)
+            )[2h:1m] offset ${local_hour}h
+          )
+          and on() (hour(vector(time() - ${local.hydration_slo_utc_offset_seconds})) == ${local_hour})
+        )
+      PROMQL
+    ])
+  }
+}
+
+moved {
+  from = grafana_slo.hydration
+  to   = grafana_slo.hydration["arthur"]
 }
 
 resource "grafana_slo" "hydration" {
-  name        = "Hydration daily target"
+  for_each = local.garmin_accounts
+
+  name        = "Hydration daily target (${each.key})"
   description = "Tracks whether daily Garmin hydration intake reaches the configured goal plus sweat loss."
 
   query {
@@ -69,7 +85,7 @@ resource "grafana_slo" "hydration" {
 
     freeform {
       query = <<-PROMQL
-        ${indent(8, local.hydration_slo_previous_day_query)}
+        ${indent(8, local.hydration_slo_previous_day_query[each.key])}
         or vector(1)
       PROMQL
     }
@@ -94,6 +110,11 @@ resource "grafana_slo" "hydration" {
     value = "garmin-health"
   }
 
+  label {
+    key   = "garmin_account"
+    value = each.key
+  }
+
   alerting {
     fastburn {
       annotation {
@@ -114,6 +135,11 @@ resource "grafana_slo" "hydration" {
       label {
         key   = "team"
         value = "garmin-health"
+      }
+
+      label {
+        key   = "garmin_account"
+        value = each.key
       }
     }
 
@@ -136,6 +162,11 @@ resource "grafana_slo" "hydration" {
       label {
         key   = "team"
         value = "garmin-health"
+      }
+
+      label {
+        key   = "garmin_account"
+        value = each.key
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add separate Arthur and Julia Garmin exporter services with account labels through the collector scrape path.
- Scope Garmin Prometheus rules, dashboard queries, Grafana Cloud hydration alerts, and SLOs by `garmin_account`.
- Update CI placeholders and local verification expectations for both exporter instances.

## Test plan
- `docker compose config --quiet`
- `promtool check rules /etc/prometheus/rules/garmin-rules.yml`
- `promtool test rules garmin-rules.test.yml`
- Collector image build and config validation
- `terraform fmt` and `terraform validate`
- `gcx resources validate --context arthursilvasens --on-error abort -p grafana/provisioning/dashboards/home`
- `CI=true scripts/verify-local-stack.sh --no-start --timeout 900`

Made with [Cursor](https://cursor.com)