### PR TITLE
Add hydration pace panel to Garmin dashboard

### DIFF
--- a/grafana/provisioning/dashboards/home/garmin.json
+++ b/grafana/provisioning/dashboards/home/garmin.json
@@ -5262,7 +5262,7 @@
                       "spec": {
                         "app": "grafana-assistant-app",
                         "editorMode": "code",
-                        "expr": "max by (garmin_account) (\n  predict_linear(\n    garmin_hydration_intake_ml_mL{garmin_account=\"$garmin_account\"}[6h],\n    scalar(\n      (19 - hour(vector(time() - 3 * 3600))) * 3600\n      - minute(vector(time() - 3 * 3600)) * 60\n    )\n  )\n)\nand on() (hour(vector(time() - 3 * 3600)) >= 7)\nand on() (hour(vector(time() - 3 * 3600)) < 19)",
+                        "expr": "max by (garmin_account) (\n  predict_linear(\n    garmin_hydration_intake_ml_mL{garmin_account=\"$garmin_account\"}[6h],\n    scalar(\n      (19 - hour(vector(time() - 3 * 3600))) * 3600\n      - minute(vector(time() - 3 * 3600)) * 60\n    )\n  )\n)",
                         "instant": false,
                         "legendFormat": "Predicted @ 7 PM",
                         "queryType": "range",
@@ -5278,7 +5278,7 @@
               "transformations": []
             }
           },
-          "description": "Same pace model as the HydrationBehindPace alert: linear regression over the last 6h, projected to 7 PM BRT. When Predicted @ 7 PM is below Goal + Sweat during 7 AM\u20137 PM, intake is behind pace.",
+          "description": "Same pace model as the HydrationBehindPace alert: linear regression over the last 6h, projected to 7 PM BRT. Shown for the full day on this panel; the alert itself only evaluates 7 AM\u20137 PM. When Predicted @ 7 PM is below Goal + Sweat, intake is behind pace.",
           "id": 108,
           "links": [],
           "title": "Hydration Pace to 7 PM",

--- a/grafana/provisioning/dashboards/home/garmin.json
+++ b/grafana/provisioning/dashboards/home/garmin.json
@@ -5193,7 +5193,276 @@
             "version": "13.2.0-30616302309"
           }
         }
+      },
+      "panel-108": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "code",
+                        "expr": "max by (garmin_account) (garmin_hydration_intake_ml_mL{garmin_account=\"$garmin_account\"})",
+                        "instant": false,
+                        "legendFormat": "Intake",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "code",
+                        "expr": "max by (garmin_account) (\n  (\n    garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"}\n    + garmin_hydration_sweat_loss_ml_mL{garmin_account=\"$garmin_account\"}\n  )\n  or garmin_hydration_goal_ml_mL{garmin_account=\"$garmin_account\"}\n)",
+                        "instant": false,
+                        "legendFormat": "Goal + Sweat",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "editorMode": "code",
+                        "expr": "max by (garmin_account) (\n  predict_linear(\n    garmin_hydration_intake_ml_mL{garmin_account=\"$garmin_account\"}[6h],\n    scalar(\n      (19 - hour(vector(time() - 3 * 3600))) * 3600\n      - minute(vector(time() - 3 * 3600)) * 60\n    )\n  )\n)\nand on() (hour(vector(time() - 3 * 3600)) >= 7)\nand on() (hour(vector(time() - 3 * 3600)) < 19)",
+                        "instant": false,
+                        "legendFormat": "Predicted @ 7 PM",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Same pace model as the HydrationBehindPace alert: linear regression over the last 6h, projected to 7 PM BRT. When Predicted @ 7 PM is below Goal + Sweat during 7 AM\u20137 PM, intake is behind pace.",
+          "id": 108,
+          "links": [],
+          "title": "Hydration Pace to 7 PM",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "mL"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Intake"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 20
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                      },
+                      {
+                        "id": "custom.lineInterpolation",
+                        "value": "stepAfter"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Goal + Sweat"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                      },
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "fill": "solid"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Predicted @ 7 PM"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-orange",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            10,
+                            10
+                          ],
+                          "fill": "dash"
+                        }
+                      },
+                      {
+                        "id": "custom.showPoints",
+                        "value": "never"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-30616302309"
+          }
+        }
       }
+
     },
     "layout": {
       "kind": "RowsLayout",
@@ -5897,6 +6166,19 @@
                         "width": 12,
                         "x": 12,
                         "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-108"
+                        },
+                        "height": 9,
+                        "width": 24,
+                        "x": 0,
+                        "y": 8
                       }
                     }
                   ]


### PR DESCRIPTION
## Summary
- Adds a **Hydration Pace to 7 PM** timeseries panel under the Hydration row on the Garmin dashboard.
- Shows intake, goal + sweat, and the same `predict_linear` 7 PM BRT forecast used by `HydrationBehindPace`.
- Styles the forecast as a light dashed series so pace vs target is easy to read at a glance.

## Test plan
- [ ] Confirm dashboard JSON validates (`gcx resources validate` / CI dashboard check)
- [ ] After Git Sync, open Garmin Health & Fitness → Hydration row
- [ ] Verify panel shows Intake, Goal + Sweat, and Predicted @ 7 PM for `$garmin_account`
- [ ] Confirm prediction only appears during 7 AM–7 PM BRT and matches alert semantics when below goal


Made with [Cursor](https://cursor.com)